### PR TITLE
Updated dropOff controller fix to use interrupts properly

### DIFF
--- a/src/behaviours/src/DropOffController.cpp
+++ b/src/behaviours/src/DropOffController.cpp
@@ -50,6 +50,7 @@ Result DropOffController::DoWork() {
             result.type = behavior;
             result.b = nextProcess;
             result.reset = true;
+            finalInterrupt = true;
             cout << "drop: behavior change" << endl;
             return result;
         }
@@ -255,6 +256,11 @@ void DropOffController::Reset() {
     reachedCollectionPoint = false;
     seenEnoughCenterTags = false;
     circularCenterSearching = false;
+    isPrecisionDriving = false;
+    finalInterrupt = false;
+    precisionInterrupt = false;
+    targetHeld = false;
+    startWaypoint = false;
 
 }
 
@@ -302,6 +308,9 @@ bool DropOffController::ShouldInterrupt() {
     else if (isPrecisionDriving && !precisionInterrupt) {
         precisionInterrupt = true;
         return true;
+    }
+    if (finalInterrupt) {
+      return true;
     }
 }
 

--- a/src/behaviours/src/DropOffController.h
+++ b/src/behaviours/src/DropOffController.h
@@ -117,6 +117,7 @@ private:
 
     bool interrupt = false;
     bool precisionInterrupt = false;
+    bool finalInterrupt = false;
 
 };
 #endif // end header define

--- a/src/behaviours/src/LogicController.cpp
+++ b/src/behaviours/src/LogicController.cpp
@@ -138,14 +138,10 @@ Result LogicController::DoWork() {
         cout << "precision command"<< endl;
 
         result = control_queue.top().controller->DoWork();
-        if (result.type == behavior) {
-          logicState = LOGIC_STATE_INTERRUPT;
-        }
-        else {
-          driveController.setResultData(result);
-          result = driveController.DoWork();
-          break;
-        }
+
+        driveController.setResultData(result);
+        result = driveController.DoWork();
+        break;
     }
     }
 


### PR DESCRIPTION
By throwing an interrupt when the dropOffController is finished precision driving and is ready to change modes.