### PR TITLE
bug fix: removed a "cout" print statement that can cause crashes

### DIFF
--- a/src/behaviours/src/LogicController.cpp
+++ b/src/behaviours/src/LogicController.cpp
@@ -169,7 +169,8 @@ Result LogicController::DoWork() {
   }//end of precision case****************************************************************************************
   }//end switch statment******************************************************************************************
 
-    cout << "logic state " << logicState << " top controller " << control_queue.top().priority << " Proccess " << processState <<endl;
+   // bad! causes node to crash
+   // cout << "logic state " << logicState << " top controller " << control_queue.top().priority << " Proccess " << processState <<endl;
 
 
   //now using proccess logic allow the controller to communicate data between eachother


### PR DESCRIPTION
The problem:
    A debugging cout print statement references variables that
    may or may not be initialized properly, which causes the
    node to crash.

The solution:
    The offending print out statement has been removed.