### PR TITLE
Hotfix 1.3.5 alpha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ devel
 **/CMakeLists.txt.user*
 *.swp
 logs
+.catkin_tools

--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -208,7 +228,7 @@
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">

--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -202,13 +222,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Yellow</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +245,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Yellow</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -260,10 +280,10 @@
 				</material>
 			</visual>
 			<collision name="collision">
-				<pose>0.0 0 -0.013 0 0 0</pose>
+			  <pose>0.0 0 -0.0055 0 0 0</pose>
 				<geometry>
 					<box>
-						<size>0.05 0.06 0.08</size>
+					  <size>0.07 0.05 0.07</size>
 					</box>
 				</geometry>
 			</collision>
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -681,21 +701,21 @@
 
 			<!-- optional: set the default PID values for the wrist joint -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
-			<wristPID>2.5 0.0 0.0</wristPID>
+      <wristPID>1.0 0.0 0.0</wristPID>
 
 			<!-- optional: set the default PID values for the finger joints -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
 			<!-- it is always assumed that both fingers use the same PID values -->
-			<fingerPID>2.5 0.0 0.0</fingerPID>
+      <fingerPID>1.0 0.0 0.0</fingerPID>
 
 			<!-- optional: set the min/max force applicable to the wrist joint in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
-			<wristForceLimits>-10 10</wristForceLimits>
+      <wristForceLimits>-0.5 0.5</wristForceLimits>
 
 			<!-- optional: set the min/max force applicable to the finger joints in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
 			<!-- it is always assumed that both fingers use the same min/max force values -->
-			<fingerForceLimits>-10 10</fingerForceLimits>
+      <fingerForceLimits>-0.5 0.5</fingerForceLimits>
 		</plugin>
 
 		<!-- Skid Steer Drive plugin -->

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -202,13 +222,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/White</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +245,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/White</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -260,10 +280,10 @@
 				</material>
 			</visual>
 			<collision name="collision">
-				<pose>0.0 0 -0.013 0 0 0</pose>
+			  <pose>0.0 0 -0.0055 0 0 0</pose>
 				<geometry>
 					<box>
-						<size>0.05 0.06 0.08</size>
+					  <size>0.07 0.05 0.07</size>
 					</box>
 				</geometry>
 			</collision>
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -681,21 +701,21 @@
 
 			<!-- optional: set the default PID values for the wrist joint -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
-			<wristPID>2.5 0.0 0.0</wristPID>
+      <wristPID>1.0 0.0 0.0</wristPID>
 
 			<!-- optional: set the default PID values for the finger joints -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
 			<!-- it is always assumed that both fingers use the same PID values -->
-			<fingerPID>2.5 0.0 0.0</fingerPID>
+      <fingerPID>1.0 0.0 0.0</fingerPID>
 
 			<!-- optional: set the min/max force applicable to the wrist joint in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
-			<wristForceLimits>-10 10</wristForceLimits>
+      <wristForceLimits>-0.5 0.5</wristForceLimits>
 
 			<!-- optional: set the min/max force applicable to the finger joints in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
 			<!-- it is always assumed that both fingers use the same min/max force values -->
-			<fingerForceLimits>-10 10</fingerForceLimits>
+      <fingerForceLimits>-0.5 0.5</fingerForceLimits>
 		</plugin>
 
 		<!-- Skid Steer Drive plugin -->

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -202,13 +222,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Red</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +245,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Red</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -260,10 +280,10 @@
 				</material>
 			</visual>
 			<collision name="collision">
-				<pose>0.0 0 -0.013 0 0 0</pose>
+			  <pose>0.0 0 -0.0055 0 0 0</pose>
 				<geometry>
 					<box>
-						<size>0.05 0.06 0.08</size>
+					  <size>0.07 0.05 0.07</size>
 					</box>
 				</geometry>
 			</collision>
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -681,21 +701,21 @@
 
 			<!-- optional: set the default PID values for the wrist joint -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
-			<wristPID>2.5 0.0 0.0</wristPID>
+      <wristPID>1.0 0.0 0.0</wristPID>
 
 			<!-- optional: set the default PID values for the finger joints -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
 			<!-- it is always assumed that both fingers use the same PID values -->
-			<fingerPID>2.5 0.0 0.0</fingerPID>
+      <fingerPID>1.0 0.0 0.0</fingerPID>
 
 			<!-- optional: set the min/max force applicable to the wrist joint in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
-			<wristForceLimits>-10 10</wristForceLimits>
+      <wristForceLimits>-0.5 0.5</wristForceLimits>
 
 			<!-- optional: set the min/max force applicable to the finger joints in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
 			<!-- it is always assumed that both fingers use the same min/max force values -->
-			<fingerForceLimits>-10 10</fingerForceLimits>
+      <fingerForceLimits>-0.5 0.5</fingerForceLimits>
 		</plugin>
 
 		<!-- Skid Steer Drive plugin -->

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -202,13 +222,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Blue</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +245,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Blue</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -260,10 +280,10 @@
 				</material>
 			</visual>
 			<collision name="collision">
-				<pose>0.0 0 -0.013 0 0 0</pose>
+			  <pose>0.0 0 -0.0055 0 0 0</pose>
 				<geometry>
 					<box>
-						<size>0.05 0.06 0.08</size>
+					  <size>0.07 0.05 0.07</size>
 					</box>
 				</geometry>
 			</collision>
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -681,21 +701,21 @@
 
 			<!-- optional: set the default PID values for the wrist joint -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
-			<wristPID>2.5 0.0 0.0</wristPID>
+      <wristPID>1.0 0.0 0.0</wristPID>
 
 			<!-- optional: set the default PID values for the finger joints -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
 			<!-- it is always assumed that both fingers use the same PID values -->
-			<fingerPID>2.5 0.0 0.0</fingerPID>
+      <fingerPID>1.0 0.0 0.0</fingerPID>
 
 			<!-- optional: set the min/max force applicable to the wrist joint in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
-			<wristForceLimits>-10 10</wristForceLimits>
+      <wristForceLimits>-0.5 0.5</wristForceLimits>
 
 			<!-- optional: set the min/max force applicable to the finger joints in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
 			<!-- it is always assumed that both fingers use the same min/max force values -->
-			<fingerForceLimits>-10 10</fingerForceLimits>
+      <fingerForceLimits>-0.5 0.5</fingerForceLimits>
 		</plugin>
 
 		<!-- Skid Steer Drive plugin -->

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -6,14 +6,14 @@
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3.0</mass>
+				<mass>3</mass>
 				<inertia>
-					<ixx>0.06</ixx>
+					<ixx>0.006</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.06</iyy>
+					<iyy>0.006</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.06</izz>
+					<izz>0.006</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -93,7 +93,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>
+					<scan>3.0
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -184,6 +184,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -192,6 +202,16 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -202,13 +222,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Orange</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
+				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -225,7 +245,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Orange</name>
+						<name>Gazebo/FlatBlack</name>
 					</script>
 				</material>
 			</visual>
@@ -237,12 +257,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -260,10 +280,10 @@
 				</material>
 			</visual>
 			<collision name="collision">
-				<pose>0.0 0 -0.013 0 0 0</pose>
+			  <pose>0.0 0 -0.0055 0 0 0</pose>
 				<geometry>
 					<box>
-						<size>0.05 0.06 0.08</size>
+					  <size>0.07 0.05 0.07</size>
 					</box>
 				</geometry>
 			</collision>
@@ -288,7 +308,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.001</mass>
+				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -369,7 +389,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.001</mass>
+ 				<mass>0.005</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -411,7 +431,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">
+			<visual name="visual">3.0
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -450,14 +470,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
+					<ixx>0.000776</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
+					<iyy>0.0012</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+					<izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -502,14 +522,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -554,14 +574,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000082</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000063</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -606,14 +626,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>0.05</mass>
+				<mass>1.0</mass>
 				<inertia>
-					<ixx>0.000082</ixx>
-					<ixy>0.0</ixy>
-					<ixz>0.0</ixz>
-					<iyy>0.000063</iyy>
-					<iyz>0.0</iyz>
-					<izz>0.000082</izz>
+         <ixx>0.000776</ixx>
+         <ixy>0.0</ixy>
+         <ixz>0.0</ixz>
+         <iyy>0.0012</iyy>
+         <iyz>0.0</iyz>
+         <izz>0.000776</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -681,21 +701,21 @@
 
 			<!-- optional: set the default PID values for the wrist joint -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
-			<wristPID>2.5 0.0 0.0</wristPID>
+      <wristPID>1.0 0.0 0.0</wristPID>
 
 			<!-- optional: set the default PID values for the finger joints -->
 			<!-- values in order: Proportional gain, Integral gain, Derivative gain -->
 			<!-- it is always assumed that both fingers use the same PID values -->
-			<fingerPID>2.5 0.0 0.0</fingerPID>
+      <fingerPID>1.0 0.0 0.0</fingerPID>
 
 			<!-- optional: set the min/max force applicable to the wrist joint in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
-			<wristForceLimits>-10 10</wristForceLimits>
+      <wristForceLimits>-0.5 0.5</wristForceLimits>
 
 			<!-- optional: set the min/max force applicable to the finger joints in Newtons -->
 			<!-- values in order: minimum force, maximum force -->
 			<!-- it is always assumed that both fingers use the same min/max force values -->
-			<fingerForceLimits>-10 10</fingerForceLimits>
+      <fingerForceLimits>-0.5 0.5</fingerForceLimits>
 		</plugin>
 
 		<!-- Skid Steer Drive plugin -->

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -25,23 +25,6 @@
 				</geometry>
 			</collision>
 
-            <collision name ='base_link_left_tire_block_blocker'>
-				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-            <collision name ='base_link_right_tire_block_blocker'>
-				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
-				<geometry>
-					<box>
-					  <size>0.005 0.08 0.06</size>
-					</box>
-				</geometry>
-            </collision>
-
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -24,6 +24,24 @@
 					</box>
 				</geometry>
 			</collision>
+
+            <collision name ='base_link_left_tire_block_blocker'>
+				<pose>0.16 0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+            <collision name ='base_link_right_tire_block_blocker'>
+				<pose>0.16 -0.13 -0.05 0 0.0 0.0</pose>
+				<geometry>
+					<box>
+					  <size>0.005 0.08 0.06</size>
+					</box>
+				</geometry>
+            </collision>
+
 			<visual name='base_link_visual'>
 				<pose>0 0 -0.06 0 0 0</pose>
 				<geometry>

--- a/simulation/models/thor/model.config
+++ b/simulation/models/thor/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+	<name>thor</name>
+	<version>1.0</version>
+	<sdf version='1.4'>model.sdf</sdf>
+
+	<author>
+		<name>NASA Swarmathon</name>
+		<email>swarmathon@cs.unm.edu</email>
+	</author>
+
+	<description>
+		Swarmie Version Three
+	</description>
+</model>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -202,6 +202,17 @@
 					</box>
 				</geometry>
 			</collision>
+
+			
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -210,6 +221,17 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
+			
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -1,19 +1,19 @@
 <?xml version='1.0'?>
 <sdf version='1.4'>
-	<model name="diomedes">
+	<model name="thor">
 
 		<static>false</static>
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3</mass>
+				<mass>3.0</mass>
 				<inertia>
-					<ixx>0.006</ixx>
+					<ixx>0.06</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.006</iyy>
+					<iyy>0.06</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.006</izz>
+					<izz>0.06</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -77,7 +77,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarLeft</topicName>
+					<topicName>/thor/sonarLeft</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -102,7 +102,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarRight</topicName>
+					<topicName>/thor/sonarRight</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -111,7 +111,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>3.0
+					<scan>
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -127,7 +127,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarCenter</topicName>
+					<topicName>/thor/sonarCenter</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -155,9 +155,9 @@
 				<plugin name="camera_controller" filename="libgazebo_ros_camera.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>0.0</updateRate>
-					<cameraName>/diomedes/camera</cameraName>
-					<imageTopicName>/diomedes/camera/image</imageTopicName>
-					<cameraInfoTopicName>/diomedes/camera/info</cameraInfoTopicName>
+					<cameraName>/thor/camera</cameraName>
+					<imageTopicName>/thor/camera/image</imageTopicName>
+					<cameraInfoTopicName>/thor/camera/info</cameraInfoTopicName>
 					<frameName>camera_link</frameName>
 					<hackBaseline>0.1</hackBaseline>
 					<distortionK1>0.0</distortionK1>
@@ -189,7 +189,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Red</name>
+						<name>Gazebo/Turquoise</name>
 					</script>
 				</material>
 			</visual>
@@ -202,16 +202,6 @@
 					</box>
 				</geometry>
 			</collision>
-      
-			<collision name='wheel_guard_front_left_collision'>
-				<pose>0.148 0.13 -0.05 0 0 0</pose>
-				<geometry>
-					<box>
-					  <size>0.01 0.08 0.06</size>
-					</box>
-				</geometry>
-			</collision>
-
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -220,16 +210,6 @@
 					</box>
 				</geometry>
 			</collision>
-      
-			<collision name='wheel_guard_front_right_collision'>
-				<pose>0.148 -0.13 -0.05 0 0 0</pose>
-				<geometry>
-					<box>
-					  <size>0.01 0.08 0.06</size>
-					</box>
-				</geometry>
-			</collision>
-      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -240,13 +220,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/FlatBlack</name>
+						<name>Gazebo/Turquoise</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
+				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -263,7 +243,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/FlatBlack</name>
+						<name>Gazebo/Turquoise</name>
 					</script>
 				</material>
 			</visual>
@@ -275,12 +255,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -326,7 +306,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.005</mass>
+				<mass>0.001</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -407,7 +387,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.005</mass>
+ 				<mass>0.001</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -449,7 +429,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">3.0
+			<visual name="visual">
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -488,14 +468,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-					<ixx>0.000776</ixx>
+					<ixx>0.000082</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.0012</iyy>
+					<iyy>0.000063</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000776</izz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -540,14 +520,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -592,14 +572,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000082</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000063</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -644,14 +624,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -701,8 +681,8 @@
 			<rightFingerJoint>gripper_right_finger_joint</rightFingerJoint>
 
 			<!-- required: data input topics for this plugin -->
-			<wristTopic>/diomedes/wristAngle/cmd</wristTopic>
-			<fingerTopic>/diomedes/fingerAngle/cmd</fingerTopic>
+			<wristTopic>/thor/wristAngle/cmd</wristTopic>
+			<fingerTopic>/thor/fingerAngle/cmd</fingerTopic>
 
 			<!-- optional: print debug info to the console -->
 			<debug>
@@ -746,11 +726,11 @@
 			<rightRearJoint>right_rear</rightRearJoint>
 			<wheelSeparation>0.27</wheelSeparation>
 			<wheelDiameter>0.12</wheelDiameter>
-			<robotBaseFrame>diomedes/base_link</robotBaseFrame>
+			<robotBaseFrame>thor/base_link</robotBaseFrame>
 			<torque>2.8</torque>
-			<commandTopic>/diomedes/skidsteer</commandTopic>
-			<odometryTopic>/diomedes/odom</odometryTopic>
-			<odometryFrame>diomedes/odom</odometryFrame>
+			<commandTopic>/thor/skidsteer</commandTopic>
+			<odometryTopic>/thor/odom</odometryTopic>
+			<odometryFrame>thor/odom</odometryFrame>
 			<broadcastTF>0</broadcastTF>base_link
 		</plugin>
 
@@ -759,8 +739,8 @@
 			<alwaysOn>1</alwaysOn>
 			<updateRate>5</updateRate>
 			<bodyName>base_link</bodyName>
-			<frameId>diomedes/base_link</frameId>
-			<topicName>/diomedes/fix</topicName>
+			<frameId>thor/base_link</frameId>
+			<topicName>/thor/fix</topicName>
 			<referenceLatitude>28.584810</referenceLatitude>
 			<referenceLongitude>-80.649650</referenceLongitude>
 			<referenceHeading>0.0</referenceHeading>
@@ -775,8 +755,8 @@
 		<plugin name="imu_sim" filename="libhector_gazebo_ros_imu.so">
 			<updateRate>10</updateRate>
 			<bodyName>base_link</bodyName>
-			<frameId>diomedes/base_link</frameId>
-			<topicName>/diomedes/imu</topicName>
+			<frameId>thor/base_link</frameId>
+			<topicName>/thor/imu</topicName>
 			<xyzOffset>0 0 0</xyzOffset>
 			<rpyOffset>0 0 0</rpyOffset>
 			<gaussianNoise>0</gaussianNoise>  

--- a/simulation/models/zeus/model.config
+++ b/simulation/models/zeus/model.config
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<model>
+	<name>zeus</name>
+	<version>1.0</version>
+	<sdf version='1.4'>model.sdf</sdf>
+
+	<author>
+		<name>NASA Swarmathon</name>
+		<email>swarmathon@cs.unm.edu</email>
+	</author>
+
+	<description>
+		Swarmie Version Three
+	</description>
+</model>

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -202,6 +202,17 @@
 					</box>
 				</geometry>
 			</collision>
+
+			
+			<collision name='wheel_guard_front_left_collision'>
+				<pose>0.148 0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -210,6 +221,17 @@
 					</box>
 				</geometry>
 			</collision>
+      
+			<collision name='wheel_guard_front_right_collision'>
+				<pose>0.148 -0.13 -0.05 0 0 0</pose>
+				<geometry>
+					<box>
+					  <size>0.01 0.08 0.06</size>
+					</box>
+				</geometry>
+			</collision>
+      
+
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -1,19 +1,19 @@
 <?xml version='1.0'?>
 <sdf version='1.4'>
-	<model name="diomedes">
+	<model name="zeus">
 
 		<static>false</static>
 
 		<link name='base_link'>
 			<inertial>
-				<mass>3</mass>
+				<mass>3.0</mass>
 				<inertia>
-					<ixx>0.006</ixx>
+					<ixx>0.06</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.006</iyy>
+					<iyy>0.06</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.006</izz>
+					<izz>0.06</izz>
 				</inertia>
 			</inertial>
 			<collision name='base_link_collision'>
@@ -77,7 +77,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarLeft</topicName>
+					<topicName>/zeus/sonarLeft</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -102,7 +102,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarRight</topicName>
+					<topicName>/zeus/sonarRight</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -111,7 +111,7 @@
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
 				<ray>
-					<scan>3.0
+					<scan>
 						<horizontal>
 							<samples>3</samples>
 							<resolution>1.0</resolution>
@@ -127,7 +127,7 @@
 				</ray>
 				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
 					<gaussianNoise>0.005</gaussianNoise>
-					<topicName>/diomedes/sonarCenter</topicName>
+					<topicName>/zeus/sonarCenter</topicName>
 					<frameId>us_center_link</frameId>
 				</plugin>
 			</sensor>
@@ -155,9 +155,9 @@
 				<plugin name="camera_controller" filename="libgazebo_ros_camera.so">
 					<alwaysOn>true</alwaysOn>
 					<updateRate>0.0</updateRate>
-					<cameraName>/diomedes/camera</cameraName>
-					<imageTopicName>/diomedes/camera/image</imageTopicName>
-					<cameraInfoTopicName>/diomedes/camera/info</cameraInfoTopicName>
+					<cameraName>/zeus/camera</cameraName>
+					<imageTopicName>/zeus/camera/image</imageTopicName>
+					<cameraInfoTopicName>/zeus/camera/info</cameraInfoTopicName>
 					<frameName>camera_link</frameName>
 					<hackBaseline>0.1</hackBaseline>
 					<distortionK1>0.0</distortionK1>
@@ -189,7 +189,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/Red</name>
+						<name>Gazebo/Indigo</name>
 					</script>
 				</material>
 			</visual>
@@ -202,16 +202,6 @@
 					</box>
 				</geometry>
 			</collision>
-      
-			<collision name='wheel_guard_front_left_collision'>
-				<pose>0.148 0.13 -0.05 0 0 0</pose>
-				<geometry>
-					<box>
-					  <size>0.01 0.08 0.06</size>
-					</box>
-				</geometry>
-			</collision>
-
 			<collision name='cow_catcher_front_right_collision'>
 				<pose>0.1675 -0.06 -0.05 0 -0.4 -0.3</pose>
 				<geometry>
@@ -220,16 +210,6 @@
 					</box>
 				</geometry>
 			</collision>
-      
-			<collision name='wheel_guard_front_right_collision'>
-				<pose>0.148 -0.13 -0.05 0 0 0</pose>
-				<geometry>
-					<box>
-					  <size>0.01 0.08 0.06</size>
-					</box>
-				</geometry>
-			</collision>
-      
 			<visual name='cow_catcher_front_visual'>
 				<pose>0.1675 0 -0.08 1.57079 0 0</pose>
 				<geometry>
@@ -240,13 +220,13 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/FlatBlack</name>
+						<name>Gazebo/Indigo</name>
 					</script>
 				</material>
 			</visual>
 
 			<collision name='cow_catcher_back_lower_collision'>
-				<pose>-0.1305 0.0 -0.0665 1.57079 1.05 0.0</pose>
+				<pose>-0.1375 0.0 -0.0725 1.57079 1.05 0.0</pose>
 				<geometry>
 					<box>
 					  <size>0.01 0.03 0.18</size>
@@ -263,7 +243,7 @@
 				</geometry>
 				<material>
 					<script>
-						<name>Gazebo/FlatBlack</name>
+						<name>Gazebo/Indigo</name>
 					</script>
 				</material>
 			</visual>
@@ -275,12 +255,12 @@
 			<inertial>
 				<mass>0.03</mass>
 				<inertia> 
-					<ixx>0.00245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
+					<ixx>0.245</ixx> <!--> 1/12*(mass)(h^2 + d^2) where h,d,w are in meters and mass is in kilograms <-->
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.00185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
+					<iyy>0.185</iyy> <!--> 1/12*(mass)(w^2 + d^2) <-->
 					<iyz>0.0</iyz>
-					<izz>0.00185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
+					<izz>0.185</izz> <!--> 1/12*(mass)(w^2 + h^2) <-->
 				</inertia>
 			</inertial>
 
@@ -326,7 +306,7 @@
 		<link name="gripper_left_finger">
 			<pose>0.214 0.016 0.0095 0 0 0</pose>
 			<inertial>
-				<mass>0.005</mass>
+				<mass>0.001</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -407,7 +387,7 @@
 		<link name="gripper_right_finger">
 			<pose>0.214 -0.016 0.0095 0 0 0</pose>
 			<inertial>
- 				<mass>0.005</mass>
+ 				<mass>0.001</mass>
 				<inertia>
 					<ixx>0.0000833</ixx>
 					<ixy>0.0</ixy>
@@ -449,7 +429,7 @@
 					</friction>
 				</surface>
 			</collision>
-			<visual name="visual">3.0
+			<visual name="visual">
 				<pose>0 0 0 0 0 0</pose>
 				<geometry>
 					<mesh>
@@ -488,14 +468,14 @@
 		<link name="left_front_wheel">
 			<pose>0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-					<ixx>0.000776</ixx>
+					<ixx>0.000082</ixx>
 					<ixy>0.0</ixy>
 					<ixz>0.0</ixz>
-					<iyy>0.0012</iyy>
+					<iyy>0.000063</iyy>
 					<iyz>0.0</iyz>
-					<izz>0.000776</izz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -540,14 +520,14 @@
 		<link name="right_front_wheel">base_link
 			<pose>0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -592,14 +572,14 @@
 		<link name="left_rear_wheel">
 			<pose>-0.095 0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000082</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000063</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -644,14 +624,14 @@
 		<link name="right_rear_wheel">
 			<pose>-0.095 -0.135 -0.03 0 0 0</pose>
 			<inertial>
-				<mass>1.0</mass>
+				<mass>0.05</mass>
 				<inertia>
-         <ixx>0.000776</ixx>
-         <ixy>0.0</ixy>
-         <ixz>0.0</ixz>
-         <iyy>0.0012</iyy>
-         <iyz>0.0</iyz>
-         <izz>0.000776</izz>
+					<ixx>0.000082</ixx>
+					<ixy>0.0</ixy>
+					<ixz>0.0</ixz>
+					<iyy>0.000063</iyy>
+					<iyz>0.0</iyz>
+					<izz>0.000082</izz>
 				</inertia>
 			</inertial>
 			<collision name="collision">
@@ -701,8 +681,8 @@
 			<rightFingerJoint>gripper_right_finger_joint</rightFingerJoint>
 
 			<!-- required: data input topics for this plugin -->
-			<wristTopic>/diomedes/wristAngle/cmd</wristTopic>
-			<fingerTopic>/diomedes/fingerAngle/cmd</fingerTopic>
+			<wristTopic>/zeus/wristAngle/cmd</wristTopic>
+			<fingerTopic>/zeus/fingerAngle/cmd</fingerTopic>
 
 			<!-- optional: print debug info to the console -->
 			<debug>
@@ -746,11 +726,11 @@
 			<rightRearJoint>right_rear</rightRearJoint>
 			<wheelSeparation>0.27</wheelSeparation>
 			<wheelDiameter>0.12</wheelDiameter>
-			<robotBaseFrame>diomedes/base_link</robotBaseFrame>
+			<robotBaseFrame>zeus/base_link</robotBaseFrame>
 			<torque>2.8</torque>
-			<commandTopic>/diomedes/skidsteer</commandTopic>
-			<odometryTopic>/diomedes/odom</odometryTopic>
-			<odometryFrame>diomedes/odom</odometryFrame>
+			<commandTopic>/zeus/skidsteer</commandTopic>
+			<odometryTopic>/zeus/odom</odometryTopic>
+			<odometryFrame>zeus/odom</odometryFrame>
 			<broadcastTF>0</broadcastTF>base_link
 		</plugin>
 
@@ -759,8 +739,8 @@
 			<alwaysOn>1</alwaysOn>
 			<updateRate>5</updateRate>
 			<bodyName>base_link</bodyName>
-			<frameId>diomedes/base_link</frameId>
-			<topicName>/diomedes/fix</topicName>
+			<frameId>zeus/base_link</frameId>
+			<topicName>/zeus/fix</topicName>
 			<referenceLatitude>28.584810</referenceLatitude>
 			<referenceLongitude>-80.649650</referenceLongitude>
 			<referenceHeading>0.0</referenceHeading>
@@ -775,8 +755,8 @@
 		<plugin name="imu_sim" filename="libhector_gazebo_ros_imu.so">
 			<updateRate>10</updateRate>
 			<bodyName>base_link</bodyName>
-			<frameId>diomedes/base_link</frameId>
-			<topicName>/diomedes/imu</topicName>
+			<frameId>zeus/base_link</frameId>
+			<topicName>/zeus/imu</topicName>
 			<xyzOffset>0 0 0</xyzOffset>
 			<rpyOffset>0 0 0</rpyOffset>
 			<gaussianNoise>0</gaussianNoise>  


### PR DESCRIPTION
 updated rover model files with bumper collision boxes

The problem:
    The rovers keep driving up on top of cubes, which deviates from
    the normal behaviour found in physical rovers.

The solution:
    Bumper collision boxes have been added in front of the wheels to
    prevent them from riding on top of cubes and getting stuck.