### PR TITLE
Operational calibration of the magnetometer and EEPROM storage

### DIFF
--- a/misc/build_arduino.sh
+++ b/misc/build_arduino.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+
+arduino=/opt/arduino/arduino
+repo=~/Swarmathon-Arduino
+build=$repo/build
+sketch=$repo/Swarmathon_Arduino/Swarmathon_Arduino.ino
+
+if udevadm info /dev/ttyACM0 | grep -q Leonardo; then
+  dev=/dev/ttyACM0
+else
+  dev=/dev/ttyACM1
+fi
+
+echo "Building for Leonardo on $dev"
+
+$arduino --upload --preserve-temp-files --pref serial.port=$dev --pref build.verbose=true --pref upload.verbose=true --pref build.path=$build --pref sketchbook.path=$repo --pref board=leonardo $sketch
+
+ 

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -308,7 +308,7 @@ void parseData(string str) {
 			else if (dataSet.at(0) == "ODOM") {
 				int leftTicks = atoi(dataSet.at(2).c_str());
 				int rightTicks = atoi(dataSet.at(3).c_str());
-				int odomTS = atof(dataSet.at(4).c_str()) / 1000; // Seconds
+				double odomTS = atof(dataSet.at(4).c_str()) / 1000.0; // Seconds
 
 				double rightWheelDistance = ticksToMeters(rightTicks);
 				double leftWheelDistance = ticksToMeters(leftTicks);

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -94,6 +94,7 @@ ros::Timer publish_heartbeat_timer;
 void publishHeartBeatTimerEventHandler(const ros::TimerEvent& event);
 void modeHandler(const std_msgs::UInt8::ConstPtr& message);
 bool store_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp);
+bool start_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp);
 
 int main(int argc, char **argv) {
     
@@ -136,6 +137,7 @@ int main(int argc, char **argv) {
 
     // Service to tell the Arduino to store calibration
     ros::ServiceServer stc = aNH.advertiseService((publishedName + "/store_magnetometer_calibration"), store_calibration);
+    ros::ServiceServer str = aNH.advertiseService((publishedName + "/start_magnetometer_calibration"), start_calibration);
     
     publishTimer = aNH.createTimer(ros::Duration(deltaTime), serialActivityTimer);
     publish_heartbeat_timer = aNH.createTimer(ros::Duration(heartbeat_publish_interval), publishHeartBeatTimerEventHandler);
@@ -240,6 +242,14 @@ void wristAngleHandler(const std_msgs::Float32::ConstPtr& angle) {
 bool store_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp) {
 	char cmd[16]={'\0'};
 	sprintf(cmd, "C\n");
+	usb.sendData(cmd);
+	memset(&cmd, '\0', sizeof (cmd));
+	return true;
+}
+
+bool start_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp) {
+	char cmd[16]={'\0'};
+	sprintf(cmd, "M\n");
 	usb.sendData(cmd);
 	memset(&cmd, '\0', sizeof (cmd));
 	return true;

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -13,6 +13,7 @@
 #include <sensor_msgs/Imu.h>
 #include <sensor_msgs/Range.h>
 #include <std_msgs/UInt8.h>
+#include <std_srvs/Empty.h>
 
 //Package include
 #include <usbSerial.h>
@@ -92,6 +93,7 @@ ros::Timer publish_heartbeat_timer;
 //Callback handlers
 void publishHeartBeatTimerEventHandler(const ros::TimerEvent& event);
 void modeHandler(const std_msgs::UInt8::ConstPtr& message);
+bool store_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp);
 
 int main(int argc, char **argv) {
     
@@ -132,6 +134,8 @@ int main(int argc, char **argv) {
     wristAngleSubscriber = aNH.subscribe((publishedName + "/wristAngle/cmd"), 1, wristAngleHandler);
     modeSubscriber = aNH.subscribe((publishedName + "/mode"), 1, modeHandler);
 
+    // Service to tell the Arduino to store calibration
+    ros::ServiceServer stc = aNH.advertiseService((publishedName + "/store_magnetometer_calibration"), store_calibration);
     
     publishTimer = aNH.createTimer(ros::Duration(deltaTime), serialActivityTimer);
     publish_heartbeat_timer = aNH.createTimer(ros::Duration(heartbeat_publish_interval), publishHeartBeatTimerEventHandler);
@@ -231,6 +235,14 @@ void wristAngleHandler(const std_msgs::Float32::ConstPtr& angle) {
   }
   usb.sendData(cmd);
   memset(&cmd, '\0', sizeof (cmd));
+}
+
+bool store_calibration(std_srvs::Empty::Request &req, std_srvs::Empty::Response &rsp) {
+	char cmd[16]={'\0'};
+	sprintf(cmd, "C\n");
+	usb.sendData(cmd);
+	memset(&cmd, '\0', sizeof (cmd));
+	return true;
 }
 
 void serialActivityTimer(const ros::TimerEvent& e) {


### PR DESCRIPTION
Hello! 

**This patch has the corresponding changes for pull request number 7 in the Swarmathon-Arduino repo.**

This patch does the following: 

It adds a shell script that automates downloading of new Arduino code, which is quite handy. It assumes that you have Arduino installed in /opt/arduino and works from the command line. 

The Arduino code now reports odometry using encoder ticks and timestamps. Those values are translated into an Odometry message in sbridge.cpp. This enables me to use a PID in abridge that takes "raw" values and a low-jitter clock. 

The sbridge code has a ROS service call that tells Arduino to store observed magnetometer limits. This will allow teams to calibrate the magnetometer without having to reflash the Arduino. Here is my suggested procedure: 

  1. Start the rover as you would normally, but **DO NOT DRIVE**. The motor coils may affect your calibration. 
  2. With the robot running, connected to the GUI and ready rotate it *slowly* two to three times around the X, Y and Z axes. 
  3. Commit the calibration to the Arduino's EEPROM by executing the following command (it may be run on your laptop or from the command line on the rover because ROS is magic). 

```bash 
rosservice call /<rover-name>/store_magnetometer_calibration
```

Replace <rover-name> with the the name of the rover you're calibrating. For example:

```bash 
rosservice call /lovelace/store_magnetometer_calibration
```

  4. Your calibration is now permanently stored and will be reused until you repeat this procedure.

A note about competition day: 

Teams that start with this base code will be able to use the EEPROM calibration flashed into the competition rovers. Teams that have other uses for the EEPROM can still use this code by extending struct cal_t in the Arduino code. For example:

```c++
struct cal_t {
  uint32_t header = CAL_HEADER_WORD;
  struct cal_data_t { 
    int16_t x_min = INT16_MAX;
    int16_t x_max = INT16_MIN;
    int16_t y_min = INT16_MAX;
    int16_t y_max = INT16_MIN;
    int16_t z_min = INT16_MAX;
    int16_t z_max = INT16_MIN;
  } data;
  uint32_t crc32 = 0;
  struct my_stuff_t {
    ...
  } my_data;
} calibration;
```

That will maintain compatibility with the standard structure allowing calibration to work while giving teams  some way to flash extra stuff. I can't imagine what that might be but... 