### PR TITLE
significant improvements and streamlining to the RQT GUI interface

### DIFF
--- a/src/rqt_rover_gui/src/MapData.h
+++ b/src/rqt_rover_gui/src/MapData.h
@@ -24,6 +24,9 @@ public:
     void addTargetLocation(std::string rover, float x, float y);
     void addCollectionPoint(std::string rover, float x, float y);
 
+    void setGlobalOffset(bool display);
+    void setGlobalOffsetForRover(std::string rover, float x, float y);
+
     void clear();
     void clear(std::string rover_name);
     void lock();
@@ -56,8 +59,13 @@ public:
 private:
 
     std::map<std::string, std::vector< std::pair<float,float> > > gps_rover_path;
-    std::map<std::string, std::vector< std::pair<float,float> > >  ekf_rover_path;
-    std::map<std::string, std::vector< std::pair<float,float> > >  encoder_rover_path;
+    std::map<std::string, std::vector< std::pair<float,float> > > ekf_rover_path;
+    std::map<std::string, std::vector< std::pair<float,float> > > encoder_rover_path;
+
+    std::map<std::string, std::pair<float,float> > rover_global_offsets;
+    std::map<std::string, std::vector< std::pair<float,float> > > global_offset_gps_rover_path;
+    std::map<std::string, std::vector< std::pair<float,float> > > global_offset_ekf_rover_path;
+    std::map<std::string, std::vector< std::pair<float,float> > > global_offset_encoder_rover_path;
 
     std::map<std::string, std::vector< std::pair<float,float> > >  collection_points;
     std::map<std::string, std::vector< std::pair<float,float> > >  target_locations;
@@ -76,6 +84,8 @@ private:
     std::map<std::string, float> max_ekf_seen_y;
     std::map<std::string, float> min_ekf_seen_x;
     std::map<std::string, float> min_ekf_seen_y;
+
+    bool display_global_offset;
 
     QMutex update_mutex; // To prevent race conditions when the data is being displayed by MapFrame
 };

--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -16,621 +16,682 @@ namespace rqt_rover_gui
 
 MapFrame::MapFrame(QWidget *parent, Qt::WindowFlags flags) : QFrame(parent)
 {
-    connect(this, SIGNAL(delayedUpdate()), this, SLOT(update()), Qt::QueuedConnection);
+  connect(this, SIGNAL(delayedUpdate()), this, SLOT(update()), Qt::QueuedConnection);
 
-    // Scale coordinates
-    frame_width = this->width();
-    frame_height = this->height();
+  // Scale coordinates
+  frame_width = this->width();
+  frame_height = this->height();
 
-    // So we can keep track of relative mouse movements to make
-    // panning feel natural
-    previous_clicked_position = QPoint(0,0);
+  // So we can keep track of relative mouse movements to make
+  // panning feel natural
+  previous_clicked_position = QPoint(0,0);
 
-    auto_transform = true;
-    scale = 10;
+  auto_transform = true;
+  scale = 10;
 
-    translate_x = 0.0f;
-    translate_y = 0.0f;
-    previous_translate_x = 0.0f;
-    previous_translate_y = 0.0f;
+  translate_x = 0.0f;
+  translate_y = 0.0f;
+  previous_translate_x = 0.0f;
+  previous_translate_y = 0.0f;
 
-    scale_speed = 0.1; // The amount of zoom per mouse wheel angle change
-    translate_speed = 1.5f;
+  scale_speed = 0.1; // The amount of zoom per mouse wheel angle change
+  translate_speed = 1.5f;
 
-    display_ekf_data = false;
-    display_gps_data = false;
-    display_encoder_data = false;
+  display_ekf_data = false;
+  display_gps_data = false;
+  display_encoder_data = false;
+  display_global_offset = false;
+  display_unique_rover_colors = false;
 
-    frames = 0;
-    popout_mapframe = NULL;
-    popout_window = NULL;
+  frames = 0;
+  popout_mapframe = NULL;
+  popout_window = NULL;
 
-    map_data = NULL;
+  map_data = NULL;
 }
 
 // This can't go in the constructor or there will be an infinite regression.
 // Instead call from the main UI in it's startup routine.
 void MapFrame::createPopoutWindow( MapData * map_data )
 {
-    popout_window = new QMainWindow();
-    popout_mapframe = new MapFrame(popout_window, 0);
-    popout_mapframe->setMapData(map_data);
+  popout_window = new QMainWindow();
+  popout_mapframe = new MapFrame(popout_window, 0);
+  popout_mapframe->setMapData(map_data);
 
-    QGridLayout* layout = new QGridLayout();
-    layout->addWidget(popout_mapframe);
+  QGridLayout* layout = new QGridLayout();
+  layout->addWidget(popout_mapframe);
 
-    QWidget* central_widget = new QWidget();
-    central_widget->setLayout(layout);
+  QWidget* central_widget = new QWidget();
+  central_widget->setLayout(layout);
 
-    popout_window->setGeometry(QRect(10, 10, 500, 500));
-    popout_window->setStyleSheet("background-color: rgb(0, 0, 0); border-color: rgb(255, 255, 255);");
-    popout_window->setCentralWidget(central_widget);
+  popout_window->setGeometry(QRect(10, 10, 500, 500));
+  popout_window->setStyleSheet("background-color: rgb(0, 0, 0); border-color: rgb(255, 255, 255);");
+  popout_window->setCentralWidget(central_widget);
 
-    connect(this, SIGNAL(delayedUpdate()), popout_mapframe, SLOT(update()), Qt::QueuedConnection);
+  connect(this, SIGNAL(delayedUpdate()), popout_mapframe, SLOT(update()), Qt::QueuedConnection);
 }
 
 void MapFrame::paintEvent(QPaintEvent* event) {
-    // Begin drawing the map
-    QPainter painter(this);
-    painter.setPen(Qt::white);
-    QFont font = painter.font();
-    qreal font_size = font.pointSizeF();
-    QFontMetrics fm(font);
+  // Begin drawing the map
+  QPainter painter(this);
+  painter.setPen(Qt::white);
+  QFont font = painter.font();
+  qreal font_size = font.pointSizeF();
+  QFontMetrics fm(font);
 
-    // Track the frames per second for development purposes
-    QString frames_per_second;
-    frames_per_second = QString::number(frames / (frame_rate_timer.elapsed() / 1000.0), 'f', 0) + " FPS";
+  // Track the frames per second for development purposes
+  QString frames_per_second;
+  frames_per_second = QString::number(frames / (frame_rate_timer.elapsed() / 1000.0), 'f', 0) + " FPS";
 
-    painter.drawText(this->width()-fm.width(frames_per_second), fm.height(), frames_per_second);
+  painter.drawText(this->width()-fm.width(frames_per_second), fm.height(), frames_per_second);
 
-    frames++;
+  frames++;
 
-    if (!(frames % 100)) // time how long it takes to dispay 100 frames
-    {
-        frame_rate_timer.start();
-        frames = 0;
+  if (!(frames % 100)) // time how long it takes to dispay 100 frames
+  {
+    frame_rate_timer.start();
+    frames = 0;
+  }
+
+  // end frames per second
+
+  // Check if any rovers have been selected for display
+  if ( !map_data )
+  {
+    painter.drawText(QPoint(50,50), "No map data provided");
+    return;
+  }
+
+
+  // Check if any rovers have been selected for display
+  if ( display_list.empty() )
+  {
+    painter.drawText(QPoint(50,50), "No rover maps selected for display");
+    return;
+  }
+
+  map_data->lock();
+
+  // Colorblind friendly colors
+  QColor green(17, 192, 131);
+  QColor red(255, 65, 30);
+
+  float max_seen_x = -std::numeric_limits<float>::max(); // std::numeric_limits<float>::max() is the max possible floating point value
+  float max_seen_y = -std::numeric_limits<float>::max();
+
+  float min_seen_x = std::numeric_limits<float>::max();
+  float min_seen_y = std::numeric_limits<float>::max();
+
+  float max_seen_width = -std::numeric_limits<float>::max();
+  float max_seen_height = -std::numeric_limits<float>::max();
+
+  int no_data_offset = 0; // So the "no data" message is not overlayed if there are multiple rovers with no data.
+
+  // Repeat the display code for each rover selected by the user - Using C++11 range syntax
+  for(auto rover_to_display : display_list) {
+    if (map_data->getEKFPath(rover_to_display)->empty() && map_data->getEncoderPath(rover_to_display)->empty() && map_data->getGPSPath(rover_to_display)->empty() && map_data->getTargetLocations(rover_to_display)->empty() && map_data->getCollectionPoints(rover_to_display)->empty()) {
+      painter.drawText(QPoint(50,50+no_data_offset), QString::fromStdString(rover_to_display) + ": No data.");
+      no_data_offset += 10;
     }
-
-    // end frames per second
-
-    // Check if any rovers have been selected for display
-    if ( !map_data )
-    {
-        painter.drawText(QPoint(50,50), "No map data provided");
-        return;
+    // Check extended kalman filter has any values in it
+    else if (map_data->getEKFPath(rover_to_display)->empty()) {
+      painter.drawText(QPoint(50,50+no_data_offset), "Map Frame: No EKF data received.");
+      no_data_offset += 10;
     }
+  }
 
-
-    // Check if any rovers have been selected for display
-    if ( display_list.empty() )
-    {
-        painter.drawText(QPoint(50,50), "No rover maps selected for display");
-        return;
-    }
-
-    map_data->lock();
-
-    // Colorblind friendly colors
-    QColor green(17, 192, 131);
-    QColor red(255, 65, 30);
-
-    float max_seen_x = -std::numeric_limits<float>::max(); // std::numeric_limits<float>::max() is the max possible floating point value
-    float max_seen_y = -std::numeric_limits<float>::max();
-
-    float min_seen_x = std::numeric_limits<float>::max();
-    float min_seen_y = std::numeric_limits<float>::max();
-
-    float max_seen_width = -std::numeric_limits<float>::max();
-    float max_seen_height = -std::numeric_limits<float>::max();
-
-    int no_data_offset = 0; // So the "no data" message is not overlayed if there are multiple rovers with no data.
-
-    // Repeat the display code for each rover selected by the user - Using C++11 range syntax
-    for(auto rover_to_display : display_list) {
-	    if (map_data->getEKFPath(rover_to_display)->empty() && map_data->getEncoderPath(rover_to_display)->empty() && map_data->getGPSPath(rover_to_display)->empty() && map_data->getTargetLocations(rover_to_display)->empty() && map_data->getCollectionPoints(rover_to_display)->empty()) {
-        painter.drawText(QPoint(50,50+no_data_offset), QString::fromStdString(rover_to_display) + ": No data.");
-        no_data_offset += 10;
-	    }
-
-	    // Check extended kalman filter has any values in it
-	    else if (map_data->getEKFPath(rover_to_display)->empty()) {
-        painter.drawText(QPoint(50,50+no_data_offset), "Map Frame: No EKF data received.");
-        no_data_offset += 10;
-	    }
-    }
-
-    // Calculate the map bounds if in auto transform mode. Iterate over the
-    // rovers and get the min and max data values scale the map to include
-    // these values
-    if (auto_transform)
-    {
-        for(auto rover_to_display : display_list)
-        {
-            // Set the max and min seen values depending on which data the user
-            // has selected to view
-
-            // Check each of the display data options and choose the most
-            // extreme value from those selected by the user
-
-            // Always include the ekf data because that is what we are using to
-            // position the current position marker for the rover
-
-            if (display_ekf_data)
-            {
-                if (min_seen_x > map_data->getMinEKFX(rover_to_display)) min_seen_x = map_data->getMinEKFX(rover_to_display);
-                if (min_seen_y > map_data->getMinEKFY(rover_to_display)) min_seen_y = map_data->getMinEKFY(rover_to_display);
-                if (max_seen_x < map_data->getMaxEKFX(rover_to_display)) max_seen_x = map_data->getMaxEKFX(rover_to_display);
-                if (max_seen_y < map_data->getMaxEKFY(rover_to_display)) max_seen_y = map_data->getMaxEKFY(rover_to_display);
-            }
-
-            if (display_gps_data)
-            {
-                if (min_seen_x > map_data->getMinGPSX(rover_to_display)) min_seen_x = map_data->getMinGPSX(rover_to_display);
-                if (min_seen_y > map_data->getMinGPSY(rover_to_display)) min_seen_y = map_data->getMinGPSY(rover_to_display);
-                if (max_seen_x < map_data->getMaxGPSX(rover_to_display)) max_seen_x = map_data->getMaxGPSX(rover_to_display);
-                if (max_seen_y < map_data->getMaxGPSY(rover_to_display)) max_seen_y = map_data->getMaxGPSY(rover_to_display);
-            }
-
-            if (display_encoder_data)
-            {
-                if (min_seen_x > map_data->getMinEncoderX(rover_to_display)) min_seen_x = map_data->getMinEncoderX(rover_to_display);
-                if (min_seen_y > map_data->getMinEncoderY(rover_to_display)) min_seen_y = map_data->getMinEncoderY(rover_to_display);
-                if (max_seen_x < map_data->getMaxEncoderX(rover_to_display)) max_seen_x = map_data->getMaxEncoderX(rover_to_display);
-                if (max_seen_y < map_data->getMaxEncoderY(rover_to_display)) max_seen_y = map_data->getMaxEncoderY(rover_to_display);
-            }
-
-            // Normalize the displayed coordinates to the largest coordinates
-            // seen since we don't know the coordinate system.
-            max_seen_width = max_seen_x-min_seen_x;
-            max_seen_height = max_seen_y-min_seen_y;
-        }
-    }
-    else
-    {
-        // Perform the manual zoom and pan transform
-
-        max_seen_width = max_seen_width_when_manual_enabled * (scale * scale_speed);
-        max_seen_height = max_seen_height_when_manual_enabled * (scale * scale_speed);
-
-        min_seen_x = (min_seen_x_when_manual_enabled + translate_x) * (scale * scale_speed);
-        min_seen_y = (min_seen_y_when_manual_enabled + translate_y) * (scale * scale_speed);
-
-        // emit sendInfoLogMessage("MapFrame: paint event: manual transform: min_seen_x: " + QString::number(min_seen_x) + " min_seen_y: " + QString::number(min_seen_y));
-    }
-
-    // Maintain aspect ratio
-    max_seen_height > max_seen_width ? max_seen_width = max_seen_height : max_seen_height = max_seen_width;
-
-    // Calculate the axis positions
-    int map_origin_x = fm.width(QString::number(-max_seen_height, 'f', 1)+"m");
-    int map_origin_y = 2*fm.height();
-
-    int map_width = this->width()-1;// Minus 1 or will go off the edge
-    int map_height = this->height()-1;//
-
-    int map_center_x = map_origin_x+((map_width-map_origin_x)/2);
-    int map_center_y = map_origin_y+((map_height-map_origin_y)/2);
-
-    // The map axes do not need to be redrawn for each rover so this code is
-    // sandwiched between the two rover display list loops
-
-    // Draw the scale bars
-    //painter.setPen(Qt::gray);
-    //painter.drawLine(QPoint(map_center_x, map_origin_y), QPoint(map_center_x, map_height));
-    //painter.drawLine(QPoint(map_origin_x, map_center_y), QPoint(map_width, map_center_y));
-    //painter.setPen(Qt::white);
-
-    // Cross hairs at map display center
-    QPoint axes_origin(map_origin_x,map_origin_y);
-    QPoint x_axis(map_width,map_origin_y);
-    QPoint y_axis(map_origin_x,map_height);
-    painter.drawLine(axes_origin, x_axis);
-    painter.drawLine(axes_origin, y_axis);
-    painter.drawLine(QPoint(map_width, map_origin_y), QPoint(map_width, map_height));
-    painter.drawLine(QPoint(map_origin_x, map_height), QPoint(map_width, map_height));
-
-    // Draw north arrow
-    QPoint northArrow_point(map_center_x, 0);
-    QPoint northArrow_left(map_center_x - 5, 5);
-    QPoint northArrow_right(map_center_x + 5, 5);
-    QRect northArrow_textBox(northArrow_left.x(), northArrow_left.y(), 10, 15);
-    painter.drawLine(northArrow_left, northArrow_right);
-    painter.drawLine(northArrow_left, northArrow_point);
-    painter.drawLine(northArrow_right, northArrow_point);
-    painter.drawText(northArrow_textBox, QString("N"));
-
-    // Draw rover origin crosshairs
-    // painter.setPen(green);
-
-    float initial_x = 0.0; //map_data->getEKFPath(rover_to_display).begin()->first;
-    float initial_y = 0.001; //map_data->getEKFPath(rover_to_display).begin()->second;
-    float rover_origin_x = map_origin_x+((initial_x-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
-    float rover_origin_y = map_origin_y+((initial_y-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-    painter.setPen(Qt::gray);
-    painter.drawLine(QPoint(rover_origin_x, map_origin_y), QPoint(rover_origin_x, map_height));
-    painter.drawLine(QPoint(map_origin_x, rover_origin_y), QPoint(map_width, rover_origin_y));
-    painter.setPen(Qt::white);
-
-    int n_ticks = 6;
-    float tick_length = 5;
-    QPoint x_axis_ticks[n_ticks];
-    QPoint y_axis_ticks[n_ticks];
-
-    for (int i = 0; i < n_ticks-1; i++)
-    {
-        x_axis_ticks[i].setX(axes_origin.x()+(i+1)*map_width/n_ticks);
-        x_axis_ticks[i].setY(axes_origin.y());
-
-        y_axis_ticks[i].setX(axes_origin.x());
-        y_axis_ticks[i].setY(axes_origin.y()+(i+1)*map_height/n_ticks);
-    }
-
-    for (int i = 0; i < n_ticks-1; i++)
-    {
-        painter.drawLine(x_axis_ticks[i], QPoint(x_axis_ticks[i].x(), x_axis_ticks[i].y()+tick_length));
-        painter.drawLine(y_axis_ticks[i], QPoint(y_axis_ticks[i].x()+tick_length, y_axis_ticks[i].y()));
-    }
-
-    for (int i = 0; i < n_ticks-1; i++)
-    {
-        float fraction_of_map_to_rover_x = (rover_origin_x-map_origin_x)/map_width;
-        float fraction_of_map_to_rover_y = (rover_origin_y-map_origin_y)/map_height;
-        float x_label_f = (i+1)*max_seen_width/n_ticks-fraction_of_map_to_rover_x*max_seen_width;
-        float y_label_f = (i+1)*max_seen_height/n_ticks-fraction_of_map_to_rover_y*max_seen_height;
-
-        QString x_label = QString::number(x_label_f, 'f', 1) + "m";
-        QString y_label = QString::number(-y_label_f, 'f', 1) + "m";
-
-        int x_labels_offset_x = -(fm.width(x_label))/2;
-        int x_labels_offset_y = 0;
-
-        int y_labels_offset_x = -(fm.width(y_label));
-        int y_labels_offset_y = fm.height()/3;
-
-        painter.drawText(x_axis_ticks[i].x()+x_labels_offset_x, axes_origin.y()+x_labels_offset_y, x_label);
-        painter.drawText(axes_origin.x()+y_labels_offset_x, y_axis_ticks[i].y()+y_labels_offset_y, y_label);
-    }
-
-    // End draw scale bars
-
-    // Repeat the display code for each rover selected by the user - Using C++11 range syntax
+  // Calculate the map bounds if in auto transform mode. Iterate over the
+  // rovers and get the min and max data values scale the map to include
+  // these values
+  if (auto_transform)
+  {
     for(auto rover_to_display : display_list)
     {
-        // scale coordinates
+      // Set the max and min seen values depending on which data the user
+      // has selected to view
 
-        std::vector<QPoint> scaled_target_locations;
-        for(std::vector< pair<float,float> >::iterator it = map_data->getTargetLocations(rover_to_display)->begin(); it < map_data->getTargetLocations(rover_to_display)->end(); ++it) {
-            pair<float,float> coordinate  = *it;
-            QPoint point;
-            point.setX(map_origin_x+coordinate.first*map_width);
-            point.setY(map_origin_y+coordinate.second*map_height);
-            scaled_target_locations.push_back(point);
-        }
+      // Check each of the display data options and choose the most
+      // extreme value from those selected by the user
 
-        std::vector<QPoint> scaled_collection_points;
-        for(std::vector< pair<float,float> >::iterator it = map_data->getCollectionPoints(rover_to_display)->begin(); it < map_data->getCollectionPoints(rover_to_display)->end(); ++it) {
-            pair<float,float> coordinate  = *it;
-            QPoint point;
-            point.setX(map_origin_x+coordinate.first*map_width);
-            point.setY(map_origin_y+coordinate.second*map_height);
-            scaled_collection_points.push_back(point);
-        }
+      // Always include the ekf data because that is what we are using to
+      // position the current position marker for the rover
 
-        std::vector<QPoint> scaled_gps_rover_points;
-        for(std::vector< pair<float,float> >::iterator it = map_data->getGPSPath(rover_to_display)->begin(); it < map_data->getGPSPath(rover_to_display)->end(); ++it) {
-            pair<float,float> coordinate  = *it;
+      if (display_ekf_data)
+      {
+      if (min_seen_x > map_data->getMinEKFX(rover_to_display)) min_seen_x = map_data->getMinEKFX(rover_to_display);
+      if (min_seen_y > map_data->getMinEKFY(rover_to_display)) min_seen_y = map_data->getMinEKFY(rover_to_display);
+      if (max_seen_x < map_data->getMaxEKFX(rover_to_display)) max_seen_x = map_data->getMaxEKFX(rover_to_display);
+      if (max_seen_y < map_data->getMaxEKFY(rover_to_display)) max_seen_y = map_data->getMaxEKFY(rover_to_display);
+      }
 
-            float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
-            float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-            scaled_gps_rover_points.push_back( QPoint(x,y) );
-        }
+      if (display_gps_data)
+      {
+      if (min_seen_x > map_data->getMinGPSX(rover_to_display)) min_seen_x = map_data->getMinGPSX(rover_to_display);
+      if (min_seen_y > map_data->getMinGPSY(rover_to_display)) min_seen_y = map_data->getMinGPSY(rover_to_display);
+      if (max_seen_x < map_data->getMaxGPSX(rover_to_display)) max_seen_x = map_data->getMaxGPSX(rover_to_display);
+      if (max_seen_y < map_data->getMaxGPSY(rover_to_display)) max_seen_y = map_data->getMaxGPSY(rover_to_display);
+      }
 
-        QPainterPath scaled_ekf_rover_path;
-        for(std::vector< pair<float,float> >::iterator it = map_data->getEKFPath(rover_to_display)->begin(); it < map_data->getEKFPath(rover_to_display)->end(); ++it) {
-            pair<float,float> coordinate  = *it;
-            QPoint point;
-            float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
-            float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+      if (display_encoder_data)
+      {
+      if (min_seen_x > map_data->getMinEncoderX(rover_to_display)) min_seen_x = map_data->getMinEncoderX(rover_to_display);
+      if (min_seen_y > map_data->getMinEncoderY(rover_to_display)) min_seen_y = map_data->getMinEncoderY(rover_to_display);
+      if (max_seen_x < map_data->getMaxEncoderX(rover_to_display)) max_seen_x = map_data->getMaxEncoderX(rover_to_display);
+      if (max_seen_y < map_data->getMaxEncoderY(rover_to_display)) max_seen_y = map_data->getMaxEncoderY(rover_to_display);
+      }
 
-            // Move to the starting point of the path without drawing a line
-            if (it == map_data->getEKFPath(rover_to_display)->begin()) scaled_ekf_rover_path.moveTo(x, y);
-            scaled_ekf_rover_path.lineTo(x, y);
-        }
+      // Normalize the displayed coordinates to the largest coordinates
+      // seen since we don't know the coordinate system.
+      max_seen_width = max_seen_x-min_seen_x;
+      max_seen_height = max_seen_y-min_seen_y;
+    }
+  }
+  else
+  {
+    // Perform the manual zoom and pan transform
 
-        QPainterPath scaled_encoder_rover_path;
-        for(std::vector< pair<float,float> >::iterator it = map_data->getEncoderPath(rover_to_display)->begin(); it < map_data->getEncoderPath(rover_to_display)->end(); ++it) {
-         
-            pair<float,float> coordinate  = *it;
-            QPoint point;
-            float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
-            float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+    max_seen_width = max_seen_width_when_manual_enabled * (scale * scale_speed);
+    max_seen_height = max_seen_height_when_manual_enabled * (scale * scale_speed);
 
-            // Move to the starting point of the path without drawing a line
-            if (it == map_data->getEncoderPath(rover_to_display)->begin()) scaled_encoder_rover_path.moveTo(x, y);
+    min_seen_x = (min_seen_x_when_manual_enabled + translate_x) * (scale * scale_speed);
+    min_seen_y = (min_seen_y_when_manual_enabled + translate_y) * (scale * scale_speed);
 
-            scaled_encoder_rover_path.lineTo(x, y);
-        }
+    // emit sendInfoLogMessage("MapFrame: paint event: manual transform: min_seen_x: " + QString::number(min_seen_x) + " min_seen_y: " + QString::number(min_seen_y));
+  }
 
-        painter.setPen(red);
-        if (display_gps_data) painter.drawPoints(&scaled_gps_rover_points[0], scaled_gps_rover_points.size());
-        // if (display_gps_data) painter.drawPath(scaled_gps_rover_path);
+  // Maintain aspect ratio
+  max_seen_height > max_seen_width ? max_seen_width = max_seen_height : max_seen_height = max_seen_width;
 
-        painter.setPen(Qt::white);
-        if (display_ekf_data) painter.drawPath(scaled_ekf_rover_path);
-        painter.setPen(green);
-        if (display_encoder_data) painter.drawPath(scaled_encoder_rover_path);
+  // Calculate the axis positions
+  int map_origin_x = fm.width(QString::number(-max_seen_height, 'f', 1)+"m");
+  int map_origin_y = 2*fm.height();
 
-        painter.setPen(red);
-        QPoint* point_array = &scaled_collection_points[0];
-        painter.drawPoints(point_array, scaled_collection_points.size());
-        painter.setPen(green);
-        point_array = &scaled_target_locations[0];
-        painter.drawPoints(point_array, scaled_target_locations.size());
+  int map_width = this->width()-1;// Minus 1 or will go off the edge
+  int map_height = this->height()-1;//
 
-        // Draw a yellow circle at the current EKF estimated rover location
-        if(!map_data->getEKFPath(rover_to_display)->empty()) {
-          painter.setPen(Qt::yellow);
-          pair<float,float> current_coordinate;
-          current_coordinate = map_data->getEKFPath(rover_to_display)->back();
+  int map_center_x = map_origin_x+((map_width-map_origin_x)/2);
+  int map_center_y = map_origin_y+((map_height-map_origin_y)/2);
 
-          float x = map_origin_x+((current_coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
-          float y = map_origin_y+((current_coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-          float radius = 2.5;
+  // The map axes do not need to be redrawn for each rover so this code is
+  // sandwiched between the two rover display list loops
 
-          painter.drawEllipse(QPointF(x,y), radius, radius);
-          painter.drawText(QPoint(x,y), QString::fromStdString(rover_to_display));
-        }
+  // Draw the scale bars
+  //painter.setPen(Qt::gray);
+  //painter.drawLine(QPoint(map_center_x, map_origin_y), QPoint(map_center_x, map_height));
+  //painter.drawLine(QPoint(map_origin_x, map_center_y), QPoint(map_width, map_center_y));
+  //painter.setPen(Qt::white);
 
-        map_data->unlock();
+  // Cross hairs at map display center
+  QPoint axes_origin(map_origin_x,map_origin_y);
+  QPoint x_axis(map_width,map_origin_y);
+  QPoint y_axis(map_origin_x,map_height);
+  painter.drawLine(axes_origin, x_axis);
+  painter.drawLine(axes_origin, y_axis);
+  painter.drawLine(QPoint(map_width, map_origin_y), QPoint(map_width, map_height));
+  painter.drawLine(QPoint(map_origin_x, map_height), QPoint(map_width, map_height));
 
-        painter.setPen(Qt::white);
-    } // End rover display list set iteration
+  // Draw north arrow
+  QPoint northArrow_point(map_center_x, 0);
+  QPoint northArrow_left(map_center_x - 5, 5);
+  QPoint northArrow_right(map_center_x + 5, 5);
+  QRect northArrow_textBox(northArrow_left.x(), northArrow_left.y(), 10, 15);
+  painter.drawLine(northArrow_left, northArrow_right);
+  painter.drawLine(northArrow_left, northArrow_point);
+  painter.drawLine(northArrow_right, northArrow_point);
+  painter.drawText(northArrow_textBox, QString("N"));
 
-    // Diagnostic output
-    /*
-    font.setPointSizeF( 12 );
-    painter.drawText(QPoint(0,15), "min_seen_x: " + QString::number(min_seen_x));
-    painter.drawText(QPoint(0,30), "min_seen_y: " + QString::number(min_seen_y));
-    painter.drawText(QPoint(0,45), "max_width_seen: " + QString::number(max_seen_width));
-    painter.drawText(QPoint(0,60), "max_height_seen: " + QString::number(max_seen_height));
-    painter.drawText(QPoint(0,75), "map_origin_x: " + QString::number(map_origin_x));
-    painter.drawText(QPoint(0,90), "map_origin_y: " + QString::number(map_origin_y));
-    painter.drawText(QPoint(0,105), "map_width: " + QString::number(map_width));
-    painter.drawText(QPoint(0,120), "map_height: " + QString::number(map_height));
-    painter.drawText(QPoint(0,135), "map_center_x: " + QString::number(map_center_x));
-    */
+  // Draw rover origin crosshairs
+  // painter.setPen(green);
+
+  float initial_x = 0.0; //map_data->getEKFPath(rover_to_display).begin()->first;
+  float initial_y = 0.001; //map_data->getEKFPath(rover_to_display).begin()->second;
+  float rover_origin_x = map_origin_x+((initial_x-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
+  float rover_origin_y = map_origin_y+((initial_y-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+  painter.setPen(Qt::gray);
+  painter.drawLine(QPoint(rover_origin_x, map_origin_y), QPoint(rover_origin_x, map_height));
+  painter.drawLine(QPoint(map_origin_x, rover_origin_y), QPoint(map_width, rover_origin_y));
+  painter.setPen(Qt::white);
+
+  int n_ticks = 6;
+  float tick_length = 5;
+  QPoint x_axis_ticks[n_ticks];
+  QPoint y_axis_ticks[n_ticks];
+
+  for (int i = 0; i < n_ticks-1; i++)
+  {
+    x_axis_ticks[i].setX(axes_origin.x()+(i+1)*map_width/n_ticks);
+    x_axis_ticks[i].setY(axes_origin.y());
+
+    y_axis_ticks[i].setX(axes_origin.x());
+    y_axis_ticks[i].setY(axes_origin.y()+(i+1)*map_height/n_ticks);
+  }
+
+  for (int i = 0; i < n_ticks-1; i++)
+  {
+    painter.drawLine(x_axis_ticks[i], QPoint(x_axis_ticks[i].x(), x_axis_ticks[i].y()+tick_length));
+    painter.drawLine(y_axis_ticks[i], QPoint(y_axis_ticks[i].x()+tick_length, y_axis_ticks[i].y()));
+  }
+
+  for (int i = 0; i < n_ticks-1; i++)
+  {
+    float fraction_of_map_to_rover_x = (rover_origin_x-map_origin_x)/map_width;
+    float fraction_of_map_to_rover_y = (rover_origin_y-map_origin_y)/map_height;
+    float x_label_f = (i+1)*max_seen_width/n_ticks-fraction_of_map_to_rover_x*max_seen_width;
+    float y_label_f = (i+1)*max_seen_height/n_ticks-fraction_of_map_to_rover_y*max_seen_height;
+
+    QString x_label = QString::number(x_label_f, 'f', 1) + "m";
+    QString y_label = QString::number(-y_label_f, 'f', 1) + "m";
+
+    int x_labels_offset_x = -(fm.width(x_label))/2;
+    int x_labels_offset_y = 0;
+
+    int y_labels_offset_x = -(fm.width(y_label));
+    int y_labels_offset_y = fm.height()/3;
+
+    painter.drawText(x_axis_ticks[i].x()+x_labels_offset_x, axes_origin.y()+x_labels_offset_y, x_label);
+    painter.drawText(axes_origin.x()+y_labels_offset_x, y_axis_ticks[i].y()+y_labels_offset_y, y_label);
+  }
+
+  // End draw scale bars
+
+  int hardware_rover_color_index = 0;
+
+  // Repeat the display code for each rover selected by the user - Using C++11 range syntax
+  for(auto rover_to_display : display_list)
+  {
+    // scale coordinates
+    std::vector<QPoint> scaled_target_locations;
+    for(std::vector< pair<float,float> >::iterator it = map_data->getTargetLocations(rover_to_display)->begin(); it < map_data->getTargetLocations(rover_to_display)->end(); ++it) {
+      pair<float,float> coordinate  = *it;
+      QPoint point;
+      point.setX(map_origin_x+coordinate.first*map_width);
+      point.setY(map_origin_y+coordinate.second*map_height);
+      scaled_target_locations.push_back(point);
+    }
+
+    std::vector<QPoint> scaled_collection_points;
+    for(std::vector< pair<float,float> >::iterator it = map_data->getCollectionPoints(rover_to_display)->begin(); it < map_data->getCollectionPoints(rover_to_display)->end(); ++it) {
+      pair<float,float> coordinate  = *it;
+      QPoint point;
+      point.setX(map_origin_x+coordinate.first*map_width);
+      point.setY(map_origin_y+coordinate.second*map_height);
+      scaled_collection_points.push_back(point);
+    }
+
+    std::vector<QPoint> scaled_gps_rover_points;
+    for(std::vector< pair<float,float> >::iterator it = map_data->getGPSPath(rover_to_display)->begin(); it < map_data->getGPSPath(rover_to_display)->end(); ++it) {
+      pair<float,float> coordinate  = *it;
+
+      float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
+      float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+      scaled_gps_rover_points.push_back( QPoint(x,y) );
+    }
+
+    QPainterPath scaled_ekf_rover_path;
+    for(std::vector< pair<float,float> >::iterator it = map_data->getEKFPath(rover_to_display)->begin(); it < map_data->getEKFPath(rover_to_display)->end(); ++it) {
+      pair<float,float> coordinate  = *it;
+      QPoint point;
+      float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
+      float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+
+      // Move to the starting point of the path without drawing a line
+      if (it == map_data->getEKFPath(rover_to_display)->begin()) scaled_ekf_rover_path.moveTo(x, y);
+      scaled_ekf_rover_path.lineTo(x, y);
+    }
+
+    QPainterPath scaled_encoder_rover_path;
+    for(std::vector< pair<float,float> >::iterator it = map_data->getEncoderPath(rover_to_display)->begin(); it < map_data->getEncoderPath(rover_to_display)->end(); ++it) {
+     
+      pair<float,float> coordinate  = *it;
+      QPoint point;
+      float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
+      float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+
+      // Move to the starting point of the path without drawing a line
+      if (it == map_data->getEncoderPath(rover_to_display)->begin()) scaled_encoder_rover_path.moveTo(x, y);
+
+      scaled_encoder_rover_path.lineTo(x, y);
+    }
+
+    QColor rover_color = QColor(255, 255, 255); // white
+
+    // if we have properly set a color for simulated rovers initialise the color here
+    // also make the popout map frame aware of the colors we use here
+    if(unique_simulated_rover_colors.find(rover_to_display) != unique_simulated_rover_colors.end())
+    {
+      rover_color = unique_simulated_rover_colors[rover_to_display];
+
+      if(popout_mapframe)
+      {
+        popout_mapframe->setUniqueRoverColor(rover_to_display, unique_simulated_rover_colors[rover_to_display]);
+      }
+    }
+    // caveat in the case that
+    //     1) we haven't set sim rover colors properly
+    //     2) we are using hardware rovers
+    else if(display_unique_rover_colors)
+    {
+      rover_color = unique_physical_rover_colors[hardware_rover_color_index];
+    }
+
+    painter.setPen(rover_color);
+
+    if(!display_unique_rover_colors) painter.setPen(red);
+
+    if (display_gps_data) painter.drawPoints(&scaled_gps_rover_points[0], scaled_gps_rover_points.size());
+    // if (display_gps_data) painter.drawPath(scaled_gps_rover_path);
+
+    if(!display_unique_rover_colors) painter.setPen(Qt::white);
+
+    if (display_ekf_data) painter.drawPath(scaled_ekf_rover_path);
+
+    if(!display_unique_rover_colors) painter.setPen(green);
+
+    if (display_encoder_data) painter.drawPath(scaled_encoder_rover_path);
+
+    painter.setPen(red);
+    QPoint* point_array = &scaled_collection_points[0];
+    painter.drawPoints(point_array, scaled_collection_points.size());
+
+    painter.setPen(green);
+    point_array = &scaled_target_locations[0];
+    painter.drawPoints(point_array, scaled_target_locations.size());
+
+    // Draw a yellow circle at the current EKF estimated rover location
+    if(!map_data->getEKFPath(rover_to_display)->empty())
+    {
+      if(display_unique_rover_colors) painter.setPen(rover_color);
+      else painter.setPen(Qt::yellow);
+
+      pair<float,float> current_coordinate;
+      current_coordinate = map_data->getEKFPath(rover_to_display)->back();
+
+      float x = map_origin_x+((current_coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
+      float y = map_origin_y+((current_coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
+      float radius = 2.5;
+
+      painter.drawEllipse(QPointF(x,y), radius, radius);
+      painter.drawText(QPoint(x,y), QString::fromStdString(rover_to_display));
+    }
+
+    map_data->unlock();
 
     painter.setPen(Qt::white);
+
+    hardware_rover_color_index = (hardware_rover_color_index + 1) % 8;
+
+  } // End rover display list set iteration
+
+  // Diagnostic output
+  /*
+  font.setPointSizeF( 12 );
+  painter.drawText(QPoint(0,15), "min_seen_x: " + QString::number(min_seen_x));
+  painter.drawText(QPoint(0,30), "min_seen_y: " + QString::number(min_seen_y));
+  painter.drawText(QPoint(0,45), "max_width_seen: " + QString::number(max_seen_width));
+  painter.drawText(QPoint(0,60), "max_height_seen: " + QString::number(max_seen_height));
+  painter.drawText(QPoint(0,75), "map_origin_x: " + QString::number(map_origin_x));
+  painter.drawText(QPoint(0,90), "map_origin_y: " + QString::number(map_origin_y));
+  painter.drawText(QPoint(0,105), "map_width: " + QString::number(map_width));
+  painter.drawText(QPoint(0,120), "map_height: " + QString::number(map_height));
+  painter.drawText(QPoint(0,135), "map_center_x: " + QString::number(map_center_x));
+  */
+
+  painter.setPen(Qt::white);
 }
 
 
 void MapFrame::setDisplayEncoderData(bool display)
 {
-    display_encoder_data = display;
+  display_encoder_data = display;
 
-    if(popout_mapframe) popout_mapframe->setDisplayEncoderData(display);
+  if(popout_mapframe) popout_mapframe->setDisplayEncoderData(display);
 }
 
 void MapFrame::setDisplayGPSData(bool display)
 {
-    display_gps_data = display;
+  display_gps_data = display;
 
-    if(popout_mapframe) popout_mapframe->setDisplayGPSData(display);
+  if(popout_mapframe) popout_mapframe->setDisplayGPSData(display);
 }
 
 void MapFrame::setDisplayEKFData(bool display)
 {
-    display_ekf_data = display;
+  display_ekf_data = display;
 
-    if(popout_mapframe) popout_mapframe->setDisplayEKFData(display);
+  if(popout_mapframe) popout_mapframe->setDisplayEKFData(display);
+}
+
+void MapFrame::setGlobalOffset(bool display)
+{
+    display_global_offset = display;
+    map_data->setGlobalOffset(display);
+
+    if(popout_mapframe) popout_mapframe->setGlobalOffset(display);
+}
+
+void MapFrame::setGlobalOffsetForRover(string rover, float x, float y)
+{
+    map_data->setGlobalOffsetForRover(rover, x, y);
+}
+
+void MapFrame::setDisplayUniqueRoverColors(bool display)
+{
+    display_unique_rover_colors = display;
+
+    if(popout_mapframe) popout_mapframe->setDisplayUniqueRoverColors(display);
+}
+
+void MapFrame::setUniqueRoverColor(string rover, QColor rover_color)
+{
+    unique_rover_colors[rover] = rover_color;
 }
 
 void MapFrame::setWhetherToDisplay(string rover, bool yes)
 {
-    map_data->lock();
+  map_data->lock();
 
-    if (yes)
-    {
-        display_list.insert(rover);
-    }
-    else
-    {
-        display_list.erase(rover);
-    }
+  if (yes)
+  {
+    display_list.insert(rover);
+  }
+  else
+  {
+    display_list.erase(rover);
+  }
 
-    map_data->unlock();
+  map_data->unlock();
 
-    if(popout_mapframe) popout_mapframe->setWhetherToDisplay(rover, yes);
+  if(popout_mapframe) popout_mapframe->setWhetherToDisplay(rover, yes);
 }
 
 void MapFrame::mouseReleaseEvent(QMouseEvent *event) {
-    previous_translate_x = translate_x;
-    previous_translate_y = translate_y;
+  previous_translate_x = translate_x;
+  previous_translate_y = translate_y;
 }
 
 void MapFrame::mousePressEvent(QMouseEvent *event)
 {
-    previous_clicked_position = event->pos();
-    // emit sendInfoLogMessage("MapFrame: mouse press. x: " + QString::number(mouse_event->pos().x()) + ", y: " + QString::number(mouse_event->pos().y()));
+  previous_clicked_position = event->pos();
+  // emit sendInfoLogMessage("MapFrame: mouse press. x: " + QString::number(mouse_event->pos().x()) + ", y: " + QString::number(mouse_event->pos().y()));
 }
 
 void MapFrame::mouseMoveEvent(QMouseEvent *event)
 {
-    // Do not adjust panning in auto-transform mode.. the changes will not be reflected
-    // and will be applied only when the user clicks on manual panning mode which will
-    // cause undesired results.
-    if (auto_transform == true) return;
+  // Do not adjust panning in auto-transform mode.. the changes will not be reflected
+  // and will be applied only when the user clicks on manual panning mode which will
+  // cause undesired results.
+  if (auto_transform == true) return;
 
-    if (event->type() == QEvent::MouseMove) {
-        QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
-        float max_width = this->width();
-        float max_height = this->height();
+  if (event->type() == QEvent::MouseMove) {
+    QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
+    float max_width = this->width();
+    float max_height = this->height();
 
-        // start with the previous translate
-        translate_x = previous_translate_x;
-        translate_y = previous_translate_y;
+    // start with the previous translate
+    translate_x = previous_translate_x;
+    translate_y = previous_translate_y;
 
-        // add the scaled translation based on the previous mouse click
-        // and the current mouse position while dragging; multiply the translation
-        // by the given translate speed to keep the map lined up with mouse movement
-        translate_x += translate_speed * (previous_clicked_position.x() - mouse_event->pos().x()) / max_width;
-        translate_y += translate_speed * (previous_clicked_position.y() - mouse_event->pos().y()) / max_height;
+    // add the scaled translation based on the previous mouse click
+    // and the current mouse position while dragging; multiply the translation
+    // by the given translate speed to keep the map lined up with mouse movement
+    translate_x += translate_speed * (previous_clicked_position.x() - mouse_event->pos().x()) / max_width;
+    translate_y += translate_speed * (previous_clicked_position.y() - mouse_event->pos().y()) / max_height;
 
-        // debug info log messages
-        // emit sendInfoLogMessage("MapFrame: mouse move: translate_x: " + QString::number(translate_x) + " translate_y: " + QString::number(translate_y) + "\n");
-        // emit sendInfoLogMessage("MapFrame: mouse move: frame_width: " + QString::number(this->width()) + " frame_height: " + QString::number(this->height()));
-        // emit sendInfoLogMessage("MapFrame: mouse move: x: " + QString::number(mouse_event->pos().x()) + " y: " + QString::number(mouse_event->pos().y()));
-        // emit sendInfoLogMessage("MapFrame: mouse move: xp: " + QString::number(previous_clicked_position.x()) + " yp: " + QString::number(previous_clicked_position.y()));
-    }
+    // debug info log messages
+    // emit sendInfoLogMessage("MapFrame: mouse move: translate_x: " + QString::number(translate_x) + " translate_y: " + QString::number(translate_y) + "\n");
+    // emit sendInfoLogMessage("MapFrame: mouse move: frame_width: " + QString::number(this->width()) + " frame_height: " + QString::number(this->height()));
+    // emit sendInfoLogMessage("MapFrame: mouse move: x: " + QString::number(mouse_event->pos().x()) + " y: " + QString::number(mouse_event->pos().y()));
+    // emit sendInfoLogMessage("MapFrame: mouse move: xp: " + QString::number(previous_clicked_position.x()) + " yp: " + QString::number(previous_clicked_position.y()));
+  }
 }
 
 void MapFrame::wheelEvent(QWheelEvent *event)
 {
-    // Do not adjust the zoom in auto-transform mode.. the changes will not be reflected
-    // and will be applied only when the user clicks on manual panning mode which will
-    // cause undesired results.
-    if (auto_transform == true) return;
+  // Do not adjust the zoom in auto-transform mode.. the changes will not be reflected
+  // and will be applied only when the user clicks on manual panning mode which will
+  // cause undesired results.
+  if (auto_transform == true) return;
 
-    // 100% map zoom is set when scale = 10; 10% adjustments to 
-    // the zoom occur with each mouse wheel adjustment
-    if (event->delta() < 0) {
-      scale++;
-    } else {
-      scale--;
-    }
+  // 100% map zoom is set when scale = 10; 10% adjustments to 
+  // the zoom occur with each mouse wheel adjustment
+  if (event->delta() < 0) {
+    scale++;
+  } else {
+    scale--;
+  }
 
-    // limit the lower bound of the scale so we do not invert the map and have
-    // negative zoom values
-    if (scale <= 0) {
-      scale = 1;
-      // emit sendInfoLogMessage("Map Zoom Set: " + QString::number(scale * 10) + "% (Minimum Zoom)");
-    } else {
-      // emit sendInfoLogMessage("Map Zoom Set: " + QString::number(scale * 10) + "%");
-    }
+  // limit the lower bound of the scale so we do not invert the map and have
+  // negative zoom values
+  if (scale <= 0) {
+    scale = 1;
+    // emit sendInfoLogMessage("Map Zoom Set: " + QString::number(scale * 10) + "% (Minimum Zoom)");
+  } else {
+    // emit sendInfoLogMessage("Map Zoom Set: " + QString::number(scale * 10) + "%");
+  }
 
-    // debug info log messages
-    // emit sendInfoLogMessage("MapFrame: mouse wheel. Degrees: " + QString::number(num_degrees) + " Scale: " + QString::number(scale));
-    // emit sendInfoLogMessage("MapFrame: mouse wheel. x: " + QString::number(event->pos().x()) + " y: " + QString::number(event->pos().y()));
+  // debug info log messages
+  // emit sendInfoLogMessage("MapFrame: mouse wheel. Degrees: " + QString::number(num_degrees) + " Scale: " + QString::number(scale));
+  // emit sendInfoLogMessage("MapFrame: mouse wheel. x: " + QString::number(event->pos().x()) + " y: " + QString::number(event->pos().y()));
 }
 
 void MapFrame::setManualTransform()
 {
-    if (popout_mapframe) popout_mapframe->setManualTransform();
-    auto_transform = false;
+  if (popout_mapframe) popout_mapframe->setManualTransform();
+  auto_transform = false;
 
-    // Calculate and store the max and min values seen so far for use my the manual transform
-    float max_seen_x = -std::numeric_limits<float>::max(); // std::numeric_limits<float>::max() is the max possible floating point value
-    float max_seen_y = -std::numeric_limits<float>::max();
-    float min_seen_x = std::numeric_limits<float>::max();
-    float min_seen_y = std::numeric_limits<float>::max();
+  // Calculate and store the max and min values seen so far for use my the manual transform
+  float max_seen_x = -std::numeric_limits<float>::max(); // std::numeric_limits<float>::max() is the max possible floating point value
+  float max_seen_y = -std::numeric_limits<float>::max();
+  float min_seen_x = std::numeric_limits<float>::max();
+  float min_seen_y = std::numeric_limits<float>::max();
 
-    for (auto rover_to_display : display_list)
-    {
-        if (display_ekf_data)
-        {
-            if (min_seen_x > map_data->getMinEKFX(rover_to_display)) min_seen_x = map_data->getMinEKFX(rover_to_display);
-            if (min_seen_y > map_data->getMinEKFY(rover_to_display)) min_seen_y = map_data->getMinEKFY(rover_to_display);
-            if (max_seen_x < map_data->getMaxEKFX(rover_to_display)) max_seen_x = map_data->getMaxEKFX(rover_to_display);
-            if (max_seen_y < map_data->getMaxEKFY(rover_to_display)) max_seen_y = map_data->getMaxEKFY(rover_to_display);
-        }
+  for (auto rover_to_display : display_list)
+  {
+      if (display_ekf_data)
+      {
+        if (min_seen_x > map_data->getMinEKFX(rover_to_display)) min_seen_x = map_data->getMinEKFX(rover_to_display);
+        if (min_seen_y > map_data->getMinEKFY(rover_to_display)) min_seen_y = map_data->getMinEKFY(rover_to_display);
+        if (max_seen_x < map_data->getMaxEKFX(rover_to_display)) max_seen_x = map_data->getMaxEKFX(rover_to_display);
+        if (max_seen_y < map_data->getMaxEKFY(rover_to_display)) max_seen_y = map_data->getMaxEKFY(rover_to_display);
+      }
 
-        if (display_gps_data)
-        {
-            if (min_seen_x > map_data->getMinGPSX(rover_to_display)) min_seen_x = map_data->getMinGPSX(rover_to_display);
-            if (min_seen_y > map_data->getMinGPSY(rover_to_display)) min_seen_y = map_data->getMinGPSY(rover_to_display);
-            if (max_seen_x < map_data->getMaxGPSX(rover_to_display)) max_seen_x = map_data->getMaxGPSX(rover_to_display);
-            if (max_seen_y < map_data->getMaxGPSY(rover_to_display)) max_seen_y = map_data->getMaxGPSY(rover_to_display);
-        }
+      if (display_gps_data)
+      {
+        if (min_seen_x > map_data->getMinGPSX(rover_to_display)) min_seen_x = map_data->getMinGPSX(rover_to_display);
+        if (min_seen_y > map_data->getMinGPSY(rover_to_display)) min_seen_y = map_data->getMinGPSY(rover_to_display);
+        if (max_seen_x < map_data->getMaxGPSX(rover_to_display)) max_seen_x = map_data->getMaxGPSX(rover_to_display);
+        if (max_seen_y < map_data->getMaxGPSY(rover_to_display)) max_seen_y = map_data->getMaxGPSY(rover_to_display);
+      }
 
-        if (display_encoder_data)
-        {
-            if (min_seen_x > map_data->getMinEncoderX(rover_to_display)) min_seen_x = map_data->getMinEncoderX(rover_to_display);
-            if (min_seen_y > map_data->getMinEncoderY(rover_to_display)) min_seen_y = map_data->getMinEncoderY(rover_to_display);
-            if (max_seen_x < map_data->getMaxEncoderX(rover_to_display)) max_seen_x = map_data->getMaxEncoderX(rover_to_display);
-            if (max_seen_y < map_data->getMaxEncoderY(rover_to_display)) max_seen_y = map_data->getMaxEncoderY(rover_to_display);
-        }
-    }
+      if (display_encoder_data)
+      {
+        if (min_seen_x > map_data->getMinEncoderX(rover_to_display)) min_seen_x = map_data->getMinEncoderX(rover_to_display);
+        if (min_seen_y > map_data->getMinEncoderY(rover_to_display)) min_seen_y = map_data->getMinEncoderY(rover_to_display);
+        if (max_seen_x < map_data->getMaxEncoderX(rover_to_display)) max_seen_x = map_data->getMaxEncoderX(rover_to_display);
+        if (max_seen_y < map_data->getMaxEncoderY(rover_to_display)) max_seen_y = map_data->getMaxEncoderY(rover_to_display);
+      }
+  }
 
-    // Normalize the displayed coordinates to the largest coordinates seen since we don't know the coordinate system.
-    float max_seen_width = max_seen_x-min_seen_x;
-    float max_seen_height = max_seen_y-min_seen_y;
-    min_seen_x_when_manual_enabled = min_seen_x;
-    min_seen_y_when_manual_enabled = min_seen_y;
-    max_seen_width_when_manual_enabled = max_seen_width;
-    max_seen_height_when_manual_enabled = max_seen_height;
+  // Normalize the displayed coordinates to the largest coordinates seen since we don't know the coordinate system.
+  float max_seen_width = max_seen_x-min_seen_x;
+  float max_seen_height = max_seen_y-min_seen_y;
+  min_seen_x_when_manual_enabled = min_seen_x;
+  min_seen_y_when_manual_enabled = min_seen_y;
+  max_seen_width_when_manual_enabled = max_seen_width;
+  max_seen_height_when_manual_enabled = max_seen_height;
 
-    /* scale the translate speed with the max seen width and height */
-    translate_speed = (max_seen_width * 0.75) + (max_seen_height * 0.75);
+  /* scale the translate speed with the max seen width and height */
+  translate_speed = (max_seen_width * 0.75) + (max_seen_height * 0.75);
 }
 
 void MapFrame::setAutoTransform()
 {
-    if (popout_mapframe) popout_mapframe->setAutoTransform();
-    auto_transform = true;
-    scale = 10;
-    translate_x = 0.0f;
-    translate_y = 0.0f;
-    previous_translate_x = 0.0f;
-    previous_translate_y = 0.0f;
-    previous_clicked_position = QPoint(0,0);
+  if (popout_mapframe) popout_mapframe->setAutoTransform();
+  auto_transform = true;
+  scale = 10;
+  translate_x = 0.0f;
+  translate_y = 0.0f;
+  previous_translate_x = 0.0f;
+  previous_translate_y = 0.0f;
+  previous_clicked_position = QPoint(0,0);
 }
 
 void MapFrame::clear()
 {
-    map_data->lock();
-    display_list.clear();
-    map_data->unlock();
+  map_data->lock();
+  display_list.clear();
+  map_data->unlock();
 }
 
 void MapFrame::clear(string rover)
 {
-    map_data->lock();
-    display_list.erase(rover);
-    map_data->unlock();
+  map_data->lock();
+  display_list.erase(rover);
+  map_data->unlock();
 }
 
 void MapFrame::popout()
 {
-    if (popout_window) popout_window->show();
+  if (popout_window) popout_window->show();
 }
 
  void MapFrame::setMapData(MapData* data)
  {
-     map_data = data;
+   map_data = data;
  }
 
  void MapFrame::addToGPSRoverPath(std::string rover, float x, float y)
  {
-     if (map_data)
-     {
-        map_data->addToGPSRoverPath(rover, x, y);
-        emit delayedUpdate();
-     }
+   if (map_data)
+   {
+      map_data->addToGPSRoverPath(rover, x, y);
+      emit delayedUpdate();
+   }
  }
 
  void MapFrame::addToEncoderRoverPath(std::string rover, float x, float y)
  {
-     if (map_data)
-     {
-        map_data->addToEncoderRoverPath(rover, x, y);
-        emit delayedUpdate();
-     }
+   if (map_data)
+   {
+      map_data->addToEncoderRoverPath(rover, x, y);
+      emit delayedUpdate();
+   }
 }
 
  void MapFrame::addToEKFRoverPath(std::string rover, float x, float y)
  {
-     if (map_data)
-     {
-         map_data->addToEKFRoverPath(rover, x, y);
-         emit delayedUpdate();
-     }
+   if (map_data)
+   {
+      map_data->addToEKFRoverPath(rover, x, y);
+      emit delayedUpdate();
+   }
  }
 
 MapFrame::~MapFrame()
 {
-    // Safely erase map data - locks to make sure a frame isnt being drawn
-    // clearMap();
-    if (popout_window) delete popout_window;
+  // Safely erase map data - locks to make sure a frame isnt being drawn
+  // clearMap();
+  if (popout_window) delete popout_window;
 }
 
 }

--- a/src/rqt_rover_gui/src/MapFrame.h
+++ b/src/rqt_rover_gui/src/MapFrame.h
@@ -51,6 +51,10 @@ namespace rqt_rover_gui
       void setDisplayEncoderData(bool display);
       void setDisplayGPSData(bool display);
       void setDisplayEKFData(bool display);
+      void setGlobalOffset(bool display);
+      void setGlobalOffsetForRover(std::string rover, float x, float y);
+      void setDisplayUniqueRoverColors(bool display);
+      void setUniqueRoverColor(std::string, QColor rover_color);
 
       void addToGPSRoverPath(std::string rover, float x, float y);
       void addToEncoderRoverPath(std::string rover, float x, float y);
@@ -100,11 +104,23 @@ namespace rqt_rover_gui
       bool display_gps_data;
       bool display_ekf_data;
       bool display_encoder_data;
+      bool display_global_offset;
+      bool display_unique_rover_colors;
 
       QTime frame_rate_timer;
       int frames;
 
       set<string> display_list;
+      std::map<std::string, QColor> unique_rover_colors;
+      std::map<std::string, QColor> unique_simulated_rover_colors;
+      QColor unique_physical_rover_colors[8] = { /* green         */ QColor(  0, 255,   0),
+                                                 /* yellow        */ QColor(255, 255,   0),
+                                                 /* white         */ QColor(255, 255, 255),
+                                                 /* red           */ QColor(255,   0,   0),
+                                                 /* deep sky blue */ QColor(  0, 191, 255),
+                                                 /* hot pink      */ QColor(255, 105, 180),
+                                                 /* chocolate     */ QColor(210, 105,  30),
+                                                 /* indigo        */ QColor( 75,   0, 130) };
 
       // For external pop out window
       QMainWindow* popout_window;

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -124,6 +124,8 @@ namespace rqt_rover_gui
     connect(ui.ekf_checkbox, SIGNAL(toggled(bool)), this, SLOT(EKFCheckboxToggledEventHandler(bool)));
     connect(ui.gps_checkbox, SIGNAL(toggled(bool)), this, SLOT(GPSCheckboxToggledEventHandler(bool)));
     connect(ui.encoder_checkbox, SIGNAL(toggled(bool)), this, SLOT(encoderCheckboxToggledEventHandler(bool)));
+    connect(ui.global_offset_checkbox, SIGNAL(toggled(bool)), this, SLOT(globalOffsetCheckboxToggledEventHandler(bool)));
+    connect(ui.unique_rover_colors_checkbox, SIGNAL(toggled(bool)), this, SLOT(uniqueRoverColorsCheckboxToggledEventHandler(bool)));
     connect(ui.autonomous_control_radio_button, SIGNAL(toggled(bool)), this, SLOT(autonomousRadioButtonEventHandler(bool)));
     connect(ui.joystick_control_radio_button, SIGNAL(toggled(bool)), this, SLOT(joystickRadioButtonEventHandler(bool)));
     connect(ui.all_autonomous_button, SIGNAL(pressed()), this, SLOT(allAutonomousButtonEventHandler()));
@@ -155,9 +157,13 @@ namespace rqt_rover_gui
     connect(this, SIGNAL(updateNumberOfSatellites(QString)), ui.gps_numSV_label, SLOT(setText(QString)));
     connect(this, SIGNAL(sendInfoLogMessage(QString)), this, SLOT(receiveInfoLogMessage(QString)));
     connect(this, SIGNAL(sendDiagLogMessage(QString)), this, SLOT(receiveDiagLogMessage(QString)));
+
     connect(ui.custom_world_path_button, SIGNAL(pressed()), this, SLOT(customWorldButtonEventHandler()));
     connect(ui.custom_distribution_radio_button, SIGNAL(toggled(bool)), this, SLOT(customWorldRadioButtonEventHandler(bool)));
+    connect(ui.powerlaw_distribution_radio_button, SIGNAL(toggled(bool)), this, SLOT(powerlawDistributionRadioButtonEventHandler(bool)));
+    connect(ui.unbounded_radio_button, SIGNAL(toggled(bool)), this, SLOT(unboundedRadioButtonEventHandler(bool)));
     connect(ui.override_num_rovers_checkbox, SIGNAL(toggled(bool)), this, SLOT(overrideNumRoversCheckboxToggledEventHandler(bool)));
+    connect(ui.create_savable_world_checkbox, SIGNAL(toggled(bool)), this, SLOT(createSavableWorldCheckboxToggledEventHandler(bool)));
 
     // Receive log messages from contained frames
     connect(ui.map_frame, SIGNAL(sendInfoLogMessage(QString)), this, SLOT(receiveInfoLogMessage(QString)));
@@ -211,7 +217,7 @@ namespace rqt_rover_gui
     info_log_subscriber = nh.subscribe("/infoLog", 10, &RoverGUIPlugin::infoLogMessageEventHandler, this);
     diag_log_subscriber = nh.subscribe("/diagsLog", 10, &RoverGUIPlugin::diagLogMessageEventHandler, this);
 
-    emit updateNumberOfSatellites("<font color='white'>Number of GPS Satellites: ---</font>");
+    emit updateNumberOfSatellites("<font color='white'>---</font>");
   }
 
   void RoverGUIPlugin::shutdownPlugin()
@@ -429,10 +435,10 @@ void RoverGUIPlugin::GPSNavSolutionEventHandler(const ros::MessageEvent<const ub
     // and the number of detected satellites is > 0
     if (selected_rover_name.compare("") != 0 && msg.get()->numSV > 0) {
         // Update the label in the GUI with the selected rover's information
-        QString newLabelText = "Number of GPS Satellites: " + QString::number(rover_numSV_state[selected_rover_name]);
+        QString newLabelText = QString::number(rover_numSV_state[selected_rover_name]);
         emit updateNumberOfSatellites("<font color='white'>" + newLabelText + "</font>");
     } else {
-        emit updateNumberOfSatellites("<font color='white'>Number of GPS Satellites: ---</font>");
+        emit updateNumberOfSatellites("<font color='white'>---</font>");
     }
 }
 
@@ -674,10 +680,10 @@ void RoverGUIPlugin::currentRoverChangedEventHandler(QListWidgetItem *current, Q
 
     // only update the number of satellites if a valid rover name has been selected
     if (selected_rover_name.compare("") != 0 && rover_numSV_state[selected_rover_name] > 0) {
-        QString newLabelText = "Number of GPS Satellites: " + QString::number(rover_numSV_state[selected_rover_name]);
+        QString newLabelText = QString::number(rover_numSV_state[selected_rover_name]);
         emit updateNumberOfSatellites("<font color='white'>" + newLabelText + "</font>");
     } else {
-        emit updateNumberOfSatellites("<font color='white'>Number of GPS Satellites: ---</font>");
+        emit updateNumberOfSatellites("<font color='white'>---</font>");
     }
 
     // Enable control mode radio group now that a rover has been selected
@@ -1132,6 +1138,16 @@ void RoverGUIPlugin::encoderCheckboxToggledEventHandler(bool checked)
     ui.map_frame->setDisplayEncoderData(checked);
 }
 
+void RoverGUIPlugin::globalOffsetCheckboxToggledEventHandler(bool checked)
+{
+    ui.map_frame->setGlobalOffset(checked);
+}
+
+void RoverGUIPlugin::uniqueRoverColorsCheckboxToggledEventHandler(bool checked)
+{
+    ui.map_frame->setDisplayUniqueRoverColors(checked);
+}
+
 void RoverGUIPlugin::displayDiagLogMessage(QString msg)
 {
     if (msg.isEmpty()) msg = "Message is empty";
@@ -1316,20 +1332,20 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
     ui.autonomous_control_radio_button->setChecked(true);
     ui.joystick_frame->setHidden(true);
     
-    //Disable all autonomous button
+    // Disable all autonomous button
     ui.all_autonomous_button->setEnabled(false);
     ui.all_autonomous_button->setStyleSheet("color: grey; border:2px solid grey;");
 
-    //Experiment Timer START
+    // Experiment Timer START
 
     // this catches the case when the /clock timer is not running
     // AKA: when we are not running a simulation
     if (current_simulated_time_in_seconds > 0.0) {
-        if (ui.simulation_timer_combo_box->currentText() == "no time limit") {
+        if (ui.simulation_timer_combobox->currentText() == "no time limit") {
             timer_start_time_in_seconds = 0.0;
             timer_stop_time_in_seconds = 0.0;
             is_timer_on = false;
-        } else if (ui.simulation_timer_combo_box->currentText() == "10 min (Testing)") {
+        } else if (ui.simulation_timer_combobox->currentText() == "10 min (Testing)") {
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 600.0;
             is_timer_on = true;
@@ -1349,9 +1365,31 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
                                                  QString::number(getHours(timer_stop_time_in_seconds)) + " hours, " +
                                                  QString::number(getMinutes(timer_stop_time_in_seconds)) + " minutes, " +
                                                  QString::number(floor(getSeconds(timer_stop_time_in_seconds))) + " seconds</font>");
-            ui.simulation_timer_combo_box->setEnabled(false);
-            ui.simulation_timer_combo_box->setStyleSheet("color: grey; border:2px solid grey;");
-        } else if (ui.simulation_timer_combo_box->currentText() == "30 min (Preliminary)") {
+            ui.simulation_timer_combobox->setEnabled(false);
+            ui.simulation_timer_combobox->setStyleSheet("color: grey; border:2px solid grey;");
+        } else if (ui.simulation_timer_combobox->currentText() == "20 min (Preliminary)") {
+            timer_start_time_in_seconds = current_simulated_time_in_seconds;
+            timer_stop_time_in_seconds = timer_start_time_in_seconds + 1200.0;
+            is_timer_on = true;
+            emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
+                                    QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
+                                    QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
+                                    QString::number(getSeconds(timer_start_time_in_seconds)) + " seconds");
+            ui.simulationTimerStartLabel->setText("<font color='white'>" +
+                                                  QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
+                                                  QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
+                                                  QString::number(floor(getSeconds(timer_start_time_in_seconds))) + " seconds</font>");
+            emit sendInfoLogMessage("Setting experiment timer to stop at: " +
+                                    QString::number(getHours(timer_stop_time_in_seconds)) + " hours, " +
+                                    QString::number(getMinutes(timer_stop_time_in_seconds)) + " minutes, " +
+                                    QString::number(getSeconds(timer_stop_time_in_seconds)) + " seconds\n");
+            ui.simulationTimerStopLabel->setText("<font color='white'>" +
+                                                 QString::number(getHours(timer_stop_time_in_seconds)) + " hours, " +
+                                                 QString::number(getMinutes(timer_stop_time_in_seconds)) + " minutes, " +
+                                                 QString::number(floor(getSeconds(timer_stop_time_in_seconds))) + " seconds</font>");
+            ui.simulation_timer_combobox->setEnabled(false);
+            ui.simulation_timer_combobox->setStyleSheet("color: grey; border:2px solid grey;");
+        } else if (ui.simulation_timer_combobox->currentText() == "30 min (Preliminary)") {
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 1800.0;
             is_timer_on = true;
@@ -1371,9 +1409,9 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
                                                  QString::number(getHours(timer_stop_time_in_seconds)) + " hours, " +
                                                  QString::number(getMinutes(timer_stop_time_in_seconds)) + " minutes, " +
                                                  QString::number(floor(getSeconds(timer_stop_time_in_seconds))) + " seconds</font>");
-            ui.simulation_timer_combo_box->setEnabled(false);
-            ui.simulation_timer_combo_box->setStyleSheet("color: grey; border:2px solid grey;");
-        } else if (ui.simulation_timer_combo_box->currentText() == "60 min (Final)") {
+            ui.simulation_timer_combobox->setEnabled(false);
+            ui.simulation_timer_combobox->setStyleSheet("color: grey; border:2px solid grey;");
+        } else if (ui.simulation_timer_combobox->currentText() == "60 min (Final)") {
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 3600.0;
             is_timer_on = true;
@@ -1393,11 +1431,12 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
                                                  QString::number(getHours(timer_stop_time_in_seconds)) + " hours, " +
                                                  QString::number(getMinutes(timer_stop_time_in_seconds)) + " minutes, " +
                                                  QString::number(floor(getSeconds(timer_stop_time_in_seconds))) + " seconds</font>");
-            ui.simulation_timer_combo_box->setEnabled(false);
-            ui.simulation_timer_combo_box->setStyleSheet("color: grey; border:2px solid grey;");
+            ui.simulation_timer_combobox->setEnabled(false);
+            ui.simulation_timer_combobox->setStyleSheet("color: grey; border:2px solid grey;");
         }
     }
-    //Experiment Timer END
+
+    // Experiment Timer END
 }
 
 double RoverGUIPlugin::getHours(double seconds) {
@@ -1477,8 +1516,8 @@ void RoverGUIPlugin::allStopButtonEventHandler()
     ui.all_stop_button->setStyleSheet("color: grey; border:2px solid grey;");
 
     // reset the simulation timer variables
-    ui.simulation_timer_combo_box->setEnabled(true);
-    ui.simulation_timer_combo_box->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
+    ui.simulation_timer_combobox->setEnabled(true);
+    ui.simulation_timer_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
     ui.simulationTimerStartLabel->setText("<font color='white'>---</font>");
     ui.simulationTimerStopLabel->setText("<font color='white'>---</font>");
     timer_start_time_in_seconds = 0.0;
@@ -1521,18 +1560,61 @@ void RoverGUIPlugin::customWorldButtonEventHandler()
 void RoverGUIPlugin::customWorldRadioButtonEventHandler(bool toggled)
 {
     ui.custom_world_path_button->setEnabled(toggled);
+    ui.number_of_tags_combobox->setEnabled(!toggled);
 
     // Set the button color to reflect whether or not it is disabled
     // Clear the sim path if custom distribution it deselected
-    if( toggled )
+    if(toggled)
     {
         ui.custom_world_path_button->setStyleSheet("color: white; border:2px solid white;");
+
+        ui.number_of_tags_label->setStyleSheet("color: grey;");
+        ui.number_of_tags_combobox->setStyleSheet("color: grey; border:2px solid grey; padding: 1px 0px 1px 3px");
     }
     else
     {
         sim_mgr.setCustomWorldPath("");
         ui.custom_world_path->setText("");
         ui.custom_world_path_button->setStyleSheet("color: grey; border:2px solid grey;");
+
+        ui.number_of_tags_label->setStyleSheet("color: white;");
+        ui.number_of_tags_combobox->setStyleSheet("color: white; border:2px solid white; padding: 1px 0px 1px 3px");
+    }
+}
+
+// Currently, we cannot use the power law distribution with custon numbers of cubes.
+// I.E., we always use 256 tags, so disable the option to change the number of cubes when
+// generating a power law distribution. If we add dynamic power law distribution generation
+// in the future this block can be removed.
+void RoverGUIPlugin::powerlawDistributionRadioButtonEventHandler(bool toggled)
+{
+    ui.number_of_tags_combobox->setEnabled(!toggled);
+
+    if(!toggled)
+    {
+        ui.number_of_tags_label->setStyleSheet("color: white;");
+        ui.number_of_tags_combobox->setStyleSheet("color: white; border:2px solid white; padding: 1px 0px 1px 3px");
+    }
+    else
+    {
+        ui.number_of_tags_label->setStyleSheet("color: grey;");
+        ui.number_of_tags_combobox->setStyleSheet("color: grey; border:2px solid grey; padding: 1px 0px 1px 3px");
+    }
+}
+
+void RoverGUIPlugin::unboundedRadioButtonEventHandler(bool toggled)
+{
+    ui.unbounded_arena_size_combobox->setEnabled(toggled);
+
+    if(toggled)
+    {
+        ui.unbounded_arena_size_label->setStyleSheet("color: white;");
+        ui.unbounded_arena_size_combobox->setStyleSheet("color: white; border:2px solid white; padding: 1px 0px 1px 3px");
+    }
+    else
+    {
+        ui.unbounded_arena_size_label->setStyleSheet("color: grey;");
+        ui.unbounded_arena_size_combobox->setStyleSheet("color: grey; border:2px solid grey; padding: 1px 0px 1px 3px");
     }
 }
 
@@ -1559,199 +1641,252 @@ void RoverGUIPlugin::buildSimulationButtonEventHandler()
     QProcess* sim_server_process = sim_mgr.startGazeboServer();
     connect(sim_server_process, SIGNAL(finished(int)), this, SLOT(gazeboServerFinishedEventHandler()));
 
-
-    if (ui.final_radio_button->isChecked())
+    if (ui.final_radio_button->isChecked() && !ui.create_savable_world_checkbox->isChecked())
     {
          arena_dim = 23.1;
          addFinalsWalls();
+         emit sendInfoLogMessage(QString("Set arena size to ")+QString::number(arena_dim)+"x"+QString::number(arena_dim));
     }
-    else
+    else if (ui.prelim_radio_button->isChecked() && !ui.create_savable_world_checkbox->isChecked())
     {
         arena_dim = 15;
         addPrelimsWalls();
-    }
-
-    emit sendInfoLogMessage(QString("Set arena size to ")+QString::number(arena_dim)+"x"+QString::number(arena_dim));
-
-    if (ui.texture_combobox->currentText() == "Gravel")
-    {
-    emit sendInfoLogMessage("Adding gravel ground plane...");
-    return_msg = sim_mgr.addGroundPlane("mars_ground_plane");
-    emit sendInfoLogMessage(return_msg);
-    }
-    else if (ui.texture_combobox->currentText() == "KSC Concrete")
-    {
-    emit sendInfoLogMessage("Adding concrete ground plane...");
-    return_msg = sim_mgr.addGroundPlane("concrete_ground_plane");
-    emit sendInfoLogMessage(return_msg);
-    }
-    else if (ui.texture_combobox->currentText() == "Car park")
-    {
-    emit sendInfoLogMessage("Adding carpark ground plane...");
-    return_msg = sim_mgr.addGroundPlane("carpark_ground_plane");
-    emit sendInfoLogMessage(return_msg);
+        emit sendInfoLogMessage(QString("Set arena size to ")+QString::number(arena_dim)+"x"+QString::number(arena_dim));
     }
     else
     {
-        emit sendInfoLogMessage("Unknown ground plane...");
+        arena_dim = ui.unbounded_arena_size_combobox->currentText().toInt();
+        emit sendInfoLogMessage(QString("Set arena size to ")+QString::number(arena_dim)+"x"+QString::number(arena_dim)+" with no barriers");
     }
 
-
-    emit sendInfoLogMessage("Adding collection disk...");
-    float collection_disk_radius = 0.5; // meters
-    sim_mgr.addModel("collection_disk", "collection_disk", 0, 0, 0, collection_disk_radius);
-    score_subscriber = nh.subscribe("/collectionZone/score", 10, &RoverGUIPlugin::scoreEventHandler, this);
-    simulation_timer_subscriber = nh.subscribe("/clock", 10, &RoverGUIPlugin::simulationTimerEventHandler, this);
-
-    int n_rovers_created = 0;
-    int n_rovers = 3;
-    if (ui.final_radio_button->isChecked()) n_rovers = 6;
-
-    // If the user chose to override the number of rovers to add to the simulation read the selected value
-    if (ui.override_num_rovers_checkbox->isChecked()) n_rovers = ui.custom_num_rovers_combobox->currentText().toInt();
-
-    QProgressDialog progress_dialog;
-    progress_dialog.setWindowTitle("Creating rovers");
-    progress_dialog.setCancelButton(NULL); // no cancel button
-    progress_dialog.setWindowModality(Qt::ApplicationModal);
-    progress_dialog.setWindowFlags(progress_dialog.windowFlags() | Qt::WindowStaysOnTopHint);
-    progress_dialog.resize(500, 50);
-    progress_dialog.show();
-
-    QString rovers[6] = {"achilles", "aeneas", "ajax", "diomedes", "hector", "paris"};
-
-    /**
-     * The distance to the rover from a corner position is calculated differently
-     * than the distance to a cardinal position.
-     *
-     * The cardinal direction rovers are a straightforward calculation where:
-     *     a = the distance to the edge of the collection zone
-     *         i.e., 1/2 of the collection zone square side length
-     *     b = the 50cm distance required by the rules for placing the rover
-     *     c = offset for the simulation for the center of the rover (30cm)
-     *         i.e., the rover position is at the center of its body
-     *
-     * The corner rovers use trigonometry to calculate the distance where each
-     * value of d, e, and f, are the legs to an isosceles right triangle. In
-     * other words, we are calculating and summing X and Y offsets to position
-     * the rover.
-     *     d = a
-     *     e = xy offset to move the rover 50cm from the corner of the collection zone
-     *     f = xy offset to move the rover 30cm to account for its position being
-     *         calculated at the center of its body
-     *
-     *                       *  *          d = 0.508m
-     *                     *      *        e = 0.354m
-     *                   *          *    + f = 0.212m
-     *                 *     /*     *    ------------
-     *                 *    / | f *            1.072m
-     *                   * /--| *
-     *                    /* *
-     *                   / | e
-     *                  /--|
-     *     *************
-     *     *          /|
-     *     *         / |
-     *     *        /  | d                 a = 0.508m
-     *     *       /   |     *********     b = 0.500m
-     *     *      /    |     *       *   + c = 0.300m
-     *     *     *-----|-----*---*   *   ------------
-     *     *        a  *  b  * c     *         1.308m
-     *     *           *     *********
-     *     *           *
-     *     *           *
-     *     *           *
-     *     *************
-     */
-    QPointF rover_positions[6] =
+    if(!ui.create_savable_world_checkbox->isChecked())
     {
-      /* cardinal rovers: North, East, South, West */
-      QPointF(-1.308,  0.000), // 1.308 = distance_from_center_to_edge_of_collection_zone
-      QPointF( 0.000, -1.308), //             + 50 cm distance to rover
-      QPointF( 1.308,  0.000), //             + 30 cm distance_from_center_of_rover_to_edge_of_rover
-      QPointF( 0.000,  1.308), // 1.308m = 0.508m + 0.5m + 0.3m
-
-      /* corner rovers: Northeast, Southwest */
-      QPointF( 1.072,  1.072), // 1.072 = diagonal_distance_from_center_to_edge_of_collection_zone
-      QPointF(-1.072, -1.072)  //             + diagonal_distance_to_move_50cm
-    };                         //             + diagonal_distance_to_move_30cm
-                               // 1.072m = 0.508 + 0.354 + 0.212
-
-    /* In this case, the yaw is the value that turns rover "left" and "right" */
-    float rover_yaw[6] =
-    {
-       0.000, //  0.00 * PI
-       1.571, //  0.50 * PI
-      -3.142, // -1.00 * PI
-      -1.571, // -0.50 * PI
-      -2.356, // -0.75 * PI
-       0.785  //  0.25 * PI
-    };
-      
-    // Add rovers to the simulation and start the associated ROS nodes
-    for (int i = 0; i < n_rovers; i++)
-    {
-        emit sendInfoLogMessage("Adding rover "+rovers[i]+"...");
-        return_msg = sim_mgr.addRover(rovers[i], rover_positions[i].x(), rover_positions[i].y(), 0, 0, 0, rover_yaw[i]);
-        emit sendInfoLogMessage(return_msg);
-
-        emit sendInfoLogMessage("Starting rover node for "+rovers[i]+"...");
-        return_msg = sim_mgr.startRoverNode(rovers[i]);
-        emit sendInfoLogMessage(return_msg);
-
-        progress_dialog.setValue((++n_rovers_created)*100.0f/n_rovers);
-        qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
-        
-        if(i == 0)
+        if (ui.texture_combobox->currentText() == "Gravel")
         {
-          sleep(rover_load_delay); // Gives plugins enough time to finish loading
+            emit sendInfoLogMessage("Adding gravel ground plane...");
+            return_msg = sim_mgr.addGroundPlane("mars_ground_plane");
+            emit sendInfoLogMessage(return_msg);
+        }
+        else if (ui.texture_combobox->currentText() == "KSC Concrete")
+        {
+            emit sendInfoLogMessage("Adding concrete ground plane...");
+            return_msg = sim_mgr.addGroundPlane("concrete_ground_plane");
+            emit sendInfoLogMessage(return_msg);
+        }
+        else if (ui.texture_combobox->currentText() == "Car park")
+        {
+            emit sendInfoLogMessage("Adding carpark ground plane...");
+            return_msg = sim_mgr.addGroundPlane("carpark_ground_plane");
+            emit sendInfoLogMessage(return_msg);
+        }
+        else
+        {
+            emit sendInfoLogMessage("Unknown ground plane...");
         }
     }
+    else
+    {
+        emit sendInfoLogMessage("Not using a ground plane texture...");
+    }
 
-   if (ui.powerlaw_distribution_radio_button->isChecked())
-   {
+    if(!ui.create_savable_world_checkbox->isChecked())
+    {
+        emit sendInfoLogMessage("Adding collection disk...");
+        float collection_disk_radius = 0.5; // meters
+        sim_mgr.addModel("collection_disk", "collection_disk", 0, 0, 0, collection_disk_radius);
+        score_subscriber = nh.subscribe("/collectionZone/score", 10, &RoverGUIPlugin::scoreEventHandler, this);
+        simulation_timer_subscriber = nh.subscribe("/clock", 10, &RoverGUIPlugin::simulationTimerEventHandler, this);
+    }
+    else
+    {
+        emit sendInfoLogMessage("Not adding collection disk...");
+    }
+
+    if(!ui.create_savable_world_checkbox->isChecked())
+    {
+        int n_rovers_created = 0;
+        int n_rovers = 3;
+        if (ui.final_radio_button->isChecked()) n_rovers = 6;
+
+        // If the user chose to override the number of rovers to add to the simulation read the selected value
+        // Please notice that this will override "n_rovers = 6" above if the final radio button is selected
+        if (ui.override_num_rovers_checkbox->isChecked()) n_rovers = ui.custom_num_rovers_combobox->currentText().toInt();
+
+        QProgressDialog progress_dialog;
+        progress_dialog.setWindowTitle("Creating rovers");
+        progress_dialog.setCancelButton(NULL); // no cancel button
+        progress_dialog.setWindowModality(Qt::ApplicationModal);
+        progress_dialog.setWindowFlags(progress_dialog.windowFlags() | Qt::WindowStaysOnTopHint);
+        progress_dialog.resize(500, 50);
+        progress_dialog.show();
+
+        QString rovers[8] = {"achilles", "aeneas", "ajax", "diomedes", "hector", "paris", "thor", "zeus"};
+
+        QColor rover_colors[8] = { /* green         */ QColor(  0, 255,   0),
+                                   /* yellow        */ QColor(255, 255,   0),
+                                   /* white         */ QColor(255, 255, 255),
+                                   /* red           */ QColor(255,   0,   0),
+                                   /* deep sky blue */ QColor(  0, 191, 255),
+                                   /* hot pink      */ QColor(255, 105, 180),
+                                   /* chocolate     */ QColor(210, 105,  30),
+                                   /* indigo        */ QColor( 75,   0, 130) };
+
+        /**
+         * The distance to the rover from a corner position is calculated differently
+         * than the distance to a cardinal position.
+         *
+         * The cardinal direction rovers are a straightforward calculation where:
+         *     a = the distance to the edge of the collection zone
+         *         i.e., 1/2 of the collection zone square side length
+         *     b = the 50cm distance required by the rules for placing the rover
+         *     c = offset for the simulation for the center of the rover (30cm)
+         *         i.e., the rover position is at the center of its body
+         *
+         * The corner rovers use trigonometry to calculate the distance where each
+         * value of d, e, and f, are the legs to an isosceles right triangle. In
+         * other words, we are calculating and summing X and Y offsets to position
+         * the rover.
+         *     d = a
+         *     e = xy offset to move the rover 50cm from the corner of the collection zone
+         *     f = xy offset to move the rover 30cm to account for its position being
+         *         calculated at the center of its body
+         *
+         *                       *  *          d = 0.508m
+         *                     *      *        e = 0.354m
+         *                   *          *    + f = 0.212m
+         *                 *     /*     *    ------------
+         *                 *    / | f *            1.072m
+         *                   * /--| *
+         *                    /* *
+         *                   / | e
+         *                  /--|
+         *     *************
+         *     *          /|
+         *     *         / |
+         *     *        /  | d                 a = 0.508m
+         *     *       /   |     *********     b = 0.500m
+         *     *      /    |     *       *   + c = 0.300m
+         *     *     *-----|-----*---*   *   ------------
+         *     *        a  *  b  * c     *         1.308m
+         *     *           *     *********
+         *     *           *
+         *     *           *
+         *     *           *
+         *     *************
+         */
+        QPointF rover_positions[8] =
+        {
+          /* cardinal rovers: North, East, South, West */
+          QPointF(-1.308,  0.000), // 1.308 = distance_from_center_to_edge_of_collection_zone
+          QPointF( 0.000, -1.308), //             + 50 cm distance to rover
+          QPointF( 1.308,  0.000), //             + 30 cm distance_from_center_of_rover_to_edge_of_rover
+          QPointF( 0.000,  1.308), // 1.308m = 0.508m + 0.5m + 0.3m
+
+          /* corner rovers: Northeast, Southwest */
+          QPointF( 1.072,  1.072), // 1.072 = diagonal_distance_from_center_to_edge_of_collection_zone
+          QPointF(-1.072, -1.072), //             + diagonal_distance_to_move_50cm
+                                   //             + diagonal_distance_to_move_30cm
+                                   // 1.072m = 0.508 + 0.354 + 0.212
+
+          /* corner rovers: Northwest, Southeast */
+          QPointF(-1.072,  1.072),
+          QPointF( 1.072, -1.072)
+        };
+
+        /* In this case, the yaw is the value that turns rover "left" and "right" */
+        float rover_yaw[8] =
+        {
+           0.000, //  0.00 * PI
+           1.571, //  0.50 * PI
+          -3.142, // -1.00 * PI
+          -1.571, // -0.50 * PI
+          -2.356, // -0.75 * PI
+           0.785, //  0.25 * PI
+          -0.785, // -0.25 * PI
+           2.356  //  0.75 * PI
+        };
+
+        // Add rovers to the simulation and start the associated ROS nodes
+        for (int i = 0; i < n_rovers; i++)
+        {
+            // add the global offset for sim rovers
+            ui.map_frame->setGlobalOffsetForRover(rovers[i].toStdString(), rover_positions[i].x(), rover_positions[i].y());
+            ui.map_frame->setUniqueRoverColor(rovers[i].toStdString(), rover_colors[i]);
+
+            emit sendInfoLogMessage("Adding rover "+rovers[i]+"...");
+            return_msg = sim_mgr.addRover(rovers[i], rover_positions[i].x(), rover_positions[i].y(), 0, 0, 0, rover_yaw[i]);
+            emit sendInfoLogMessage(return_msg);
+
+            emit sendInfoLogMessage("Starting rover node for "+rovers[i]+"...");
+            return_msg = sim_mgr.startRoverNode(rovers[i]);
+            emit sendInfoLogMessage(return_msg);
+
+            progress_dialog.setValue((++n_rovers_created)*100.0f/n_rovers);
+            qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
+
+            if(i == 0)
+            {
+              sleep(rover_load_delay); // Gives plugins enough time to finish loading
+            }
+        }
+    }
+    else
+    {
+        emit sendInfoLogMessage("Not creating rovers...");
+    }
+
+    if (ui.powerlaw_distribution_radio_button->isChecked())
+    {
        emit sendInfoLogMessage("Adding powerlaw distribution of targets...");
        return_msg = addPowerLawTargets();
        emit sendInfoLogMessage(return_msg);
-   }
-   else if (ui.uniform_distribution_radio_button->isChecked())
-   {
+    }
+    else if (ui.uniform_distribution_radio_button->isChecked())
+    {
        emit sendInfoLogMessage("Adding uniform distribution of targets...");
        return_msg = addUniformTargets();
        emit sendInfoLogMessage(return_msg);
-   }
-   else if (ui.clustered_distribution_radio_button->isChecked())
-   {
+    }
+    else if (ui.clustered_distribution_radio_button->isChecked())
+    {
        emit sendInfoLogMessage("Adding clustered distribution of targets...");
        return_msg = addClusteredTargets();
        emit sendInfoLogMessage(return_msg);
-   }
+    }
 
-   // add walls given nw corner (x,y) and height and width (in meters)
+    // add walls given nw corner (x,y) and height and width (in meters)
 
-   //addWalls(-arena_dim/2, -arena_dim/2, arena_dim, arena_dim);
+    //addWalls(-arena_dim/2, -arena_dim/2, arena_dim, arena_dim);
 
-   //   // Test rover movement
-   //   displayLogMessage("Moving aeneas");
-   //   return_msg = sim_mgr.moveRover("aeneas", 10, 0, 0);
-   //   displayLogMessage(return_msg);
+    //   // Test rover movement
+    //   displayLogMessage("Moving aeneas");
+    //   return_msg = sim_mgr.moveRover("aeneas", 10, 0, 0);
+    //   displayLogMessage(return_msg);
 
-   //displayLogMessage("Starting the gazebo client to visualize the simulation.");
-   //sim_mgr.startGazeboClient();
+    //displayLogMessage("Starting the gazebo client to visualize the simulation.");
+    //sim_mgr.startGazeboClient();
 
-   ui.visualize_simulation_button->setEnabled(true);
-   ui.clear_simulation_button->setEnabled(true);
+    ui.visualize_simulation_button->setEnabled(true);
+    ui.clear_simulation_button->setEnabled(true);
 
-   ui.visualize_simulation_button->setStyleSheet("color: white;border:1px solid white;");
-   ui.clear_simulation_button->setStyleSheet("color: white;border:1px solid white;");
+    ui.visualize_simulation_button->setStyleSheet("color: white;border:1px solid white;");
+    ui.clear_simulation_button->setStyleSheet("color: white;border:1px solid white;");
 
-    ui.simulation_timer_combo_box->setEnabled(true);
-    ui.simulation_timer_combo_box->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
+    ui.simulation_timer_combobox->setEnabled(true);
+    ui.simulation_timer_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
 
-   emit sendInfoLogMessage("Finished building simulation.");
+    emit sendInfoLogMessage("Finished building simulation.");
 
-   // Visualize the simulation by default call button event handler
-   visualizeSimulationButtonEventHandler();
+    if (ui.start_visualization_on_build_checkbox->isChecked())
+    {
+        // Visualize the simulation by default call button event handler
+        visualizeSimulationButtonEventHandler();
+        display_sim_visualization = true;
+    }
+    else
+    {
+        display_sim_visualization = false;
+    }
 }
 
 void RoverGUIPlugin::clearSimulationButtonEventHandler()
@@ -1873,11 +2008,11 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
     obstacle_call_count = 0;
     emit updateObstacleCallCount("<font color='white'>0</font>");
     emit updateNumberOfTagsCollected("<font color='white'>0</font>");
-    emit updateNumberOfSatellites("<font color='white'>Number of GPS Satellites: ---</font>");
+    emit updateNumberOfSatellites("<font color='white'>---</font>");
 
     // reset the simulation timer variables
-    ui.simulation_timer_combo_box->setEnabled(true);
-    ui.simulation_timer_combo_box->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
+    ui.simulation_timer_combobox->setEnabled(true);
+    ui.simulation_timer_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
     ui.simulationTimerStartLabel->setText("<font color='white'>---</font>");
     ui.simulationTimerStopLabel->setText("<font color='white'>---</font>");
     ui.currentSimulationTimeLabel->setText("<font color='white'>---</font>");
@@ -1961,8 +2096,10 @@ QString RoverGUIPlugin::stopROSJoyNode()
 
 QString RoverGUIPlugin::addUniformTargets()
 {
+    QString number_of_tags = ui.number_of_tags_combobox->currentText();
+
     QProgressDialog progress_dialog;
-    progress_dialog.setWindowTitle("Placing 256 Targets");
+    progress_dialog.setWindowTitle("Placing " + number_of_tags + " Targets");
     progress_dialog.setCancelButton(NULL); // no cancel button
     progress_dialog.setWindowModality(Qt::ApplicationModal);
     progress_dialog.resize(500, 50);
@@ -1974,8 +2111,6 @@ QString RoverGUIPlugin::addUniformTargets()
     float proposed_x;
     float proposed_y;
 
-    // 256 piles of 1 tag
-
     // d is the distance from the center of the arena to the boundary minus the barrier clearance, i.e. the region where tags can be placed
     // is d - U(0,2d) where U(a,b) is a uniform distribition bounded by a and b.
     // (before checking for collisions including the collection disk at the center)
@@ -1984,7 +2119,7 @@ QString RoverGUIPlugin::addUniformTargets()
     progress_dialog.setValue(0.0);
     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 
-    for (int i = 0; i < 256; i++)
+    for (int i = 0; i < number_of_tags.toInt(); i++)
     {
         do
         {
@@ -1996,19 +2131,53 @@ QString RoverGUIPlugin::addUniformTargets()
 
         emit sendInfoLogMessage("<font color=green>Succeeded.</font>");
         output = sim_mgr.addModel(QString("at")+QString::number(0),  QString("at")+QString::number(i), proposed_x, proposed_y, 0, target_cluster_size_1_clearance);
-        progress_dialog.setValue(i*100.0f/256);
+        progress_dialog.setValue(i*100.0f/number_of_tags.toInt());
         qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
     }
 
-    emit sendInfoLogMessage("Placed 256 single targets");
+    emit sendInfoLogMessage("Placed " + number_of_tags + " single targets");
 
     return output;
 }
 
 QString RoverGUIPlugin::addClusteredTargets()
 {
+    QString number_of_tags = ui.number_of_tags_combobox->currentText();
+    int cluster_length = 0;
+    int cluster_width = 0;
+
+    switch(number_of_tags.toInt())
+    {
+        case 256:
+            cluster_length = 8;
+            cluster_width = 8;
+            break;
+        case 128:
+            cluster_length = 8;
+            cluster_width = 4;
+            break;
+        case 64:
+            cluster_length = 4;
+            cluster_width = 4;
+            break;
+        case 32:
+            cluster_length = 4;
+            cluster_width = 2;
+            break;
+        case 16:
+            cluster_length = 2;
+            cluster_width = 2;
+            break;
+        case 0:
+            cluster_length = 0;
+            cluster_width = 0;
+        default:
+            cluster_length = 1;
+            cluster_width = 1;
+    }
+
     QProgressDialog progress_dialog;
-    progress_dialog.setWindowTitle("Placing 256 Targets into 4 Clusters (64 targets each)");
+    progress_dialog.setWindowTitle("Placing " + number_of_tags + " Targets into four " + QString::number(cluster_length) + " x " + QString::number(cluster_width) + " clusters");
     progress_dialog.setCancelButton(NULL); // no cancel button
     progress_dialog.setWindowModality(Qt::ApplicationModal);
     progress_dialog.setWindowFlags(progress_dialog.windowFlags() | Qt::WindowStaysOnTopHint);
@@ -2020,13 +2189,14 @@ QString RoverGUIPlugin::addClusteredTargets()
     float proposed_x, proposed_x2;
     float proposed_y, proposed_y2;
 
-    float d = arena_dim/2.0-(barrier_clearance+target_cluster_size_64_clearance);
+    float target_cluster_clearance = target_cluster_size_1_clearance * ((cluster_length > cluster_width) ? (cluster_length) : (cluster_width));
+    float d = arena_dim/2.0-(barrier_clearance+target_cluster_clearance);
     int cube_index = 0;
 
     progress_dialog.setValue(0.0);
     qApp->processEvents(QEventLoop::ExcludeUserInputEvents);
 
-    // Four piles of 64
+    // Four piles
     for (int i = 0; i < 4; i++)
     {
         do
@@ -2035,14 +2205,14 @@ QString RoverGUIPlugin::addClusteredTargets()
             proposed_x = d - ((float) rand()) / RAND_MAX*2*d;
             proposed_y = d - ((float) rand()) / RAND_MAX*2*d;
         }
-        while (sim_mgr.isLocationOccupied(proposed_x, proposed_y, target_cluster_size_64_clearance));
+        while (sim_mgr.isLocationOccupied(proposed_x, proposed_y, target_cluster_clearance));
 
-        proposed_y2 = proposed_y - (target_cluster_size_1_clearance * 8);
+        proposed_y2 = proposed_y - (target_cluster_size_1_clearance * cluster_length);
 
-        for(int j = 0; j < 8; j++) {
-            proposed_x2 = proposed_x - (target_cluster_size_1_clearance * 8);
+        for(int j = 0; j < cluster_length; j++) {
+            proposed_x2 = proposed_x - (target_cluster_size_1_clearance * cluster_width);
 
-            for(int k = 0; k < 8; k++) {
+            for(int k = 0; k < cluster_width; k++) {
                 output += sim_mgr.addModel(QString("at")+QString::number(0),  QString("at")+QString::number(cube_index), proposed_x2, proposed_y2, 0, target_cluster_size_1_clearance);
                 proposed_x2 += target_cluster_size_1_clearance;
                 cube_index++;
@@ -2056,7 +2226,7 @@ QString RoverGUIPlugin::addClusteredTargets()
         emit sendInfoLogMessage("<font color=green>Succeeded.</font>");
     }
 
-    emit sendInfoLogMessage("Placed four clusters of 64 targets");
+    emit sendInfoLogMessage("Placed four " + QString::number(cluster_length) + " x " + QString::number(cluster_width) + " clusters of targets");
 
     return output;
 }
@@ -2623,6 +2793,49 @@ void RoverGUIPlugin::overrideNumRoversCheckboxToggledEventHandler(bool checked)
     ui.custom_num_rovers_combobox->setEnabled(checked);
     if (checked) ui.custom_num_rovers_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px"); // The padding makes the item list color change work
     else ui.custom_num_rovers_combobox->setStyleSheet("color: grey; border:1px solid grey;");
+}
+
+void RoverGUIPlugin::createSavableWorldCheckboxToggledEventHandler(bool checked)
+{
+    ui.round_type_button_group->setEnabled(!checked);
+    ui.custom_num_rovers_combobox->setEnabled(!checked);
+    ui.override_num_rovers_checkbox->setEnabled(!checked);
+    ui.ground_texture_label->setEnabled(!checked);
+    ui.texture_combobox->setEnabled(!checked);
+    ui.simulation_timer_label->setEnabled(!checked);
+    ui.simulation_timer_combobox->setEnabled(!checked);
+
+    ui.prelim_radio_button->click();
+    unboundedRadioButtonEventHandler(false);
+
+    // change specific GUI elements to the "disabled" color scheme
+    if(checked)
+    {
+        ui.round_type_button_group->setStyleSheet("color: grey;");
+        ui.prelim_radio_button->setStyleSheet("color: grey;");
+        ui.final_radio_button->setStyleSheet("color: grey;");
+        ui.unbounded_radio_button->setStyleSheet("color: grey;");
+        ui.custom_num_rovers_combobox->setStyleSheet("color: grey; border:1px solid grey; padding: 1px 0px 1px 3px;");
+        ui.override_num_rovers_checkbox->setStyleSheet("clor: grey;");
+        ui.ground_texture_label->setStyleSheet("color: grey;");
+        ui.texture_combobox->setStyleSheet("color: grey; border:1px solid grey; padding: 1px 0px 1px 3px;");
+        ui.simulation_timer_label->setStyleSheet("color: grey;");
+        ui.simulation_timer_combobox->setStyleSheet("color: grey; border:1px solid grey; padding: 1px 0px 1px 3px;");
+    }
+    // change specific GUI elements to the "enabled" color scheme
+    else
+    {
+        ui.round_type_button_group->setStyleSheet("color: white;");
+        ui.prelim_radio_button->setStyleSheet("color: white;");
+        ui.final_radio_button->setStyleSheet("color: white;");
+        ui.unbounded_radio_button->setStyleSheet("color: white;");
+        ui.custom_num_rovers_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px;");
+        ui.override_num_rovers_checkbox->setStyleSheet("color: white;");
+        ui.ground_texture_label->setStyleSheet("color: white");
+        ui.texture_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px;");
+        ui.simulation_timer_label->setStyleSheet("color: white;");
+        ui.simulation_timer_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px;");
+    }
 }
 
 // Slot used to update the GUI diagnostic data output. Ensures we update from the correct process.

--- a/src/rqt_rover_gui/src/rover_gui_plugin.h
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.h
@@ -173,7 +173,10 @@ namespace rqt_rover_gui {
     void GPSCheckboxToggledEventHandler(bool checked);
     void EKFCheckboxToggledEventHandler(bool checked);
     void encoderCheckboxToggledEventHandler(bool checked);
+    void globalOffsetCheckboxToggledEventHandler(bool checked);
+    void uniqueRoverColorsCheckboxToggledEventHandler(bool checked);
     void overrideNumRoversCheckboxToggledEventHandler(bool checked);
+    void createSavableWorldCheckboxToggledEventHandler(bool checked);
 
     void mapSelectionListItemChangedHandler(QListWidgetItem* changed_item);
     void mapAutoRadioButtonEventHandler(bool marked);
@@ -186,6 +189,8 @@ namespace rqt_rover_gui {
     void allStopButtonEventHandler();
     void customWorldButtonEventHandler();
     void customWorldRadioButtonEventHandler(bool marked);
+    void powerlawDistributionRadioButtonEventHandler(bool marked);
+    void unboundedRadioButtonEventHandler(bool marked);
 
     void buildSimulationButtonEventHandler();
     void clearSimulationButtonEventHandler();
@@ -260,7 +265,7 @@ namespace rqt_rover_gui {
 
     bool display_sim_visualization;
 
-    // Object clearance. These values are used to quickly determine where objects can be placed int time simulation
+    // Object clearance. These values are used to quickly determine where objects can be placed in the simulation
     float target_cluster_size_64_clearance;
     float target_cluster_size_16_clearance;
     float target_cluster_size_4_clearance;

--- a/src/rqt_rover_gui/src/rover_gui_plugin.ui
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.ui
@@ -41,7 +41,7 @@ border-color: rgb(255, 255, 255);</string>
      <x>330</x>
      <y>10</y>
      <width>761</width>
-     <height>551</height>
+     <height>521</height>
     </rect>
    </property>
    <property name="sizePolicy">
@@ -118,10 +118,10 @@ QTabBar::tab:only-one {
     <widget class="rqt_rover_gui::IMUFrame" name="imu_frame">
      <property name="geometry">
       <rect>
-       <x>350</x>
-       <y>290</y>
-       <width>281</width>
-       <height>191</height>
+       <x>246</x>
+       <y>306</y>
+       <width>209</width>
+       <height>179</height>
       </rect>
      </property>
      <property name="sizePolicy">
@@ -140,10 +140,10 @@ QTabBar::tab:only-one {
     <widget class="rqt_rover_gui::MapFrame" name="map_frame">
      <property name="geometry">
       <rect>
-       <x>350</x>
-       <y>10</y>
-       <width>320</width>
-       <height>271</height>
+       <x>392</x>
+       <y>26</y>
+       <width>354</width>
+       <height>249</height>
       </rect>
      </property>
      <property name="styleSheet">
@@ -162,10 +162,10 @@ QTabBar::tab:only-one {
     <widget class="rqt_rover_gui::USFrame" name="us_frame">
      <property name="geometry">
       <rect>
-       <x>50</x>
-       <y>290</y>
-       <width>281</width>
-       <height>191</height>
+       <x>16</x>
+       <y>306</y>
+       <width>209</width>
+       <height>179</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -178,10 +178,10 @@ QTabBar::tab:only-one {
     <widget class="rqt_rover_gui::CameraFrame" name="camera_frame">
      <property name="geometry">
       <rect>
-       <x>10</x>
-       <y>10</y>
-       <width>320</width>
-       <height>271</height>
+       <x>16</x>
+       <y>26</y>
+       <width>354</width>
+       <height>249</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -191,144 +191,425 @@ QTabBar::tab:only-one {
       <enum>QFrame::Raised</enum>
      </property>
     </widget>
-    <widget class="QCheckBox" name="gps_checkbox">
+    <widget class="QFrame" name="map_settings_frame">
      <property name="geometry">
       <rect>
-       <x>670</x>
-       <y>50</y>
-       <width>81</width>
-       <height>22</height>
+       <x>470</x>
+       <y>300</y>
+       <width>281</width>
+       <height>191</height>
       </rect>
      </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;GPS aligned with the map output (mutually recursive with MAP)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
      </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
      </property>
-     <property name="text">
-      <string>NAVSAT</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
+     <widget class="QPushButton" name="map_popout_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>145</y>
+        <width>60</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);
+border-color: rgb(255, 255, 255);
+border: 1px solid white; 
+</string>
+      </property>
+      <property name="text">
+       <string>Popout</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="ekf_checkbox">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>40</y>
+        <width>60</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;EKF combination of IMU, Encoders and GPS (mutually recursive with NAVSAT)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>MAP</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="encoder_checkbox">
+      <property name="geometry">
+       <rect>
+        <x>130</x>
+        <y>40</y>
+        <width>75</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;EKF combination of IMU and Encoders&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>ODOM</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="gps_checkbox">
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>60</y>
+        <width>91</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;GPS aligned with the map output (mutually recursive with MAP)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>NAVSAT</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="map_manual_radio_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>110</y>
+        <width>81</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Manual</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QRadioButton" name="map_auto_radio_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>130</x>
+        <y>110</y>
+        <width>61</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Auto</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="unique_rover_colors_checkbox">
+      <property name="geometry">
+       <rect>
+        <x>20</x>
+        <y>145</y>
+        <width>165</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Unique Rover Colors</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="global_offset_checkbox">
+      <property name="geometry">
+       <rect>
+        <x>130</x>
+        <y>60</y>
+        <width>121</width>
+        <height>25</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Global Frame</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="map_frame_views_label">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>20</y>
+        <width>125</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Frame Views</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="map_frame_views_label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>90</y>
+        <width>90</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Panning</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
     </widget>
-    <widget class="QCheckBox" name="ekf_checkbox">
+    <widget class="QLabel" name="map_settings_label">
      <property name="geometry">
       <rect>
-       <x>670</x>
-       <y>10</y>
-       <width>91</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;EKF combination of IMU, Encoders and GPS (mutually recursive with NAVSAT)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
-     </property>
-     <property name="text">
-      <string>MAP</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-    <widget class="QCheckBox" name="encoder_checkbox">
-     <property name="geometry">
-      <rect>
-       <x>670</x>
-       <y>30</y>
-       <width>81</width>
-       <height>22</height>
-      </rect>
-     </property>
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;EKF combination of IMU and Encoders&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
-     </property>
-     <property name="text">
-      <string>ODOM</string>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-    </widget>
-    <widget class="QRadioButton" name="map_manual_radio_button">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="geometry">
-      <rect>
-       <x>670</x>
-       <y>85</y>
-       <width>117</width>
+       <x>490</x>
+       <y>290</y>
+       <width>105</width>
        <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
      </property>
      <property name="text">
-      <string>Manual</string>
+      <string>Map Settings</string>
      </property>
-     <property name="checked">
-      <bool>false</bool>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
-     <attribute name="buttonGroup">
-      <string notr="true">map_display_button_group</string>
-     </attribute>
-    </widget>
-    <widget class="QRadioButton" name="map_auto_radio_button">
-     <property name="enabled">
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
+    </widget>
+    <widget class="QFrame" name="imu_frame_frame">
      <property name="geometry">
       <rect>
-       <x>670</x>
-       <y>110</y>
-       <width>171</width>
-       <height>16</height>
+       <x>240</x>
+       <y>300</y>
+       <width>221</width>
+       <height>191</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+    <widget class="QFrame" name="us_frame_frame">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>300</y>
+       <width>221</width>
+       <height>191</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+    <widget class="QLabel" name="IMU_label">
+     <property name="geometry">
+      <rect>
+       <x>260</x>
+       <y>290</y>
+       <width>40</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
      </property>
      <property name="text">
-      <string>Auto</string>
+      <string>IMU</string>
      </property>
-     <property name="checked">
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
       <bool>true</bool>
      </property>
-     <attribute name="buttonGroup">
-      <string notr="true">map_display_button_group</string>
-     </attribute>
     </widget>
-    <widget class="QPushButton" name="map_popout_button">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="QLabel" name="ultrasound_label">
      <property name="geometry">
       <rect>
-       <x>680</x>
-       <y>140</y>
-       <width>61</width>
-       <height>22</height>
+       <x>30</x>
+       <y>290</y>
+       <width>90</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);
-border-color: rgb(255, 255, 255);
-border: 1px solid white; 
-</string>
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
      </property>
      <property name="text">
-      <string>Popout</string>
+      <string>Ultrasound</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
+    <widget class="QFrame" name="camera_frame_frame">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>20</y>
+       <width>366</width>
+       <height>261</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+    <widget class="QFrame" name="map_frame_frame">
+     <property name="geometry">
+      <rect>
+       <x>386</x>
+       <y>20</y>
+       <width>366</width>
+       <height>261</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+    </widget>
+    <widget class="QLabel" name="map_label">
+     <property name="geometry">
+      <rect>
+       <x>406</x>
+       <y>10</y>
+       <width>40</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
+     </property>
+     <property name="text">
+      <string>Map</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <widget class="QLabel" name="map_label_2">
+     <property name="geometry">
+      <rect>
+       <x>30</x>
+       <y>10</y>
+       <width>65</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
+     </property>
+     <property name="text">
+      <string>Camera</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+    <zorder>map_frame_frame</zorder>
+    <zorder>camera_frame_frame</zorder>
+    <zorder>us_frame_frame</zorder>
+    <zorder>imu_frame_frame</zorder>
+    <zorder>map_settings_frame</zorder>
+    <zorder>imu_frame</zorder>
+    <zorder>map_frame</zorder>
+    <zorder>us_frame</zorder>
+    <zorder>camera_frame</zorder>
+    <zorder>map_settings_label</zorder>
+    <zorder>map_label_2</zorder>
+    <zorder>map_label</zorder>
+    <zorder>ultrasound_label</zorder>
+    <zorder>IMU_label</zorder>
    </widget>
    <widget class="QWidget" name="simulation_parameters_tab">
     <attribute name="title">
@@ -338,9 +619,9 @@ border: 1px solid white;
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>60</y>
-       <width>301</width>
-       <height>306</height>
+       <y>20</y>
+       <width>531</width>
+       <height>311</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -353,9 +634,9 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>10</y>
-        <width>141</width>
-        <height>161</height>
+        <y>20</y>
+        <width>161</width>
+        <height>111</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -371,10 +652,10 @@ border-color: rgb(255, 255, 255);</string>
        </property>
        <property name="geometry">
         <rect>
-         <x>30</x>
+         <x>20</x>
          <y>30</y>
          <width>91</width>
-         <height>22</height>
+         <height>16</height>
         </rect>
        </property>
        <property name="styleSheet">
@@ -393,10 +674,10 @@ border-color: rgb(255, 255, 255);</string>
        </property>
        <property name="geometry">
         <rect>
-         <x>30</x>
-         <y>90</y>
+         <x>20</x>
+         <y>70</y>
          <width>101</width>
-         <height>22</height>
+         <height>16</height>
         </rect>
        </property>
        <property name="styleSheet">
@@ -412,10 +693,10 @@ border-color: rgb(255, 255, 255);</string>
        </property>
        <property name="geometry">
         <rect>
-         <x>30</x>
-         <y>60</y>
-         <width>91</width>
-         <height>22</height>
+         <x>20</x>
+         <y>50</y>
+         <width>101</width>
+         <height>16</height>
         </rect>
        </property>
        <property name="styleSheet">
@@ -434,10 +715,10 @@ border-color: rgb(255, 255, 255);</string>
        </property>
        <property name="geometry">
         <rect>
-         <x>30</x>
-         <y>120</y>
-         <width>117</width>
-         <height>22</height>
+         <x>20</x>
+         <y>90</y>
+         <width>121</width>
+         <height>16</height>
         </rect>
        </property>
        <property name="toolTip">
@@ -447,7 +728,7 @@ border-color: rgb(255, 255, 255);</string>
         <string notr="true">color: rgb(255, 255, 255);</string>
        </property>
        <property name="text">
-        <string>Custom</string>
+        <string>Custom World</string>
        </property>
        <property name="checked">
         <bool>true</bool>
@@ -460,8 +741,8 @@ border-color: rgb(255, 255, 255);</string>
       </property>
       <property name="geometry">
        <rect>
-        <x>140</x>
-        <y>130</y>
+        <x>160</x>
+        <y>105</y>
         <width>70</width>
         <height>25</height>
        </rect>
@@ -482,10 +763,10 @@ border: 1px solid white;
      <widget class="QGroupBox" name="round_type_button_group">
       <property name="geometry">
        <rect>
-        <x>160</x>
-        <y>30</y>
-        <width>121</width>
-        <height>91</height>
+        <x>280</x>
+        <y>120</y>
+        <width>211</width>
+        <height>131</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -495,7 +776,7 @@ border-color: rgb(255, 255, 255);</string>
       <property name="title">
        <string>Round Type</string>
       </property>
-      <widget class="QRadioButton" name="joystick_radio_button">
+      <widget class="QRadioButton" name="prelim_radio_button">
        <property name="enabled">
         <bool>true</bool>
        </property>
@@ -503,7 +784,7 @@ border-color: rgb(255, 255, 255);</string>
         <rect>
          <x>10</x>
          <y>30</y>
-         <width>161</width>
+         <width>111</width>
          <height>22</height>
         </rect>
        </property>
@@ -524,8 +805,8 @@ border-color: rgb(255, 255, 255);</string>
        <property name="geometry">
         <rect>
          <x>10</x>
-         <y>60</y>
-         <width>117</width>
+         <y>50</y>
+         <width>71</width>
          <height>22</height>
         </rect>
        </property>
@@ -536,12 +817,107 @@ border-color: rgb(255, 255, 255);</string>
         <string>Final </string>
        </property>
       </widget>
+      <widget class="QRadioButton" name="unbounded_radio_button">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>10</x>
+         <y>70</y>
+         <width>111</width>
+         <height>22</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: rgb(255, 255, 255);</string>
+       </property>
+       <property name="text">
+        <string>Unbounded</string>
+       </property>
+      </widget>
+      <widget class="QLabel" name="unbounded_arena_size_label">
+       <property name="geometry">
+        <rect>
+         <x>40</x>
+         <y>98</y>
+         <width>81</width>
+         <height>20</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: grey;</string>
+       </property>
+       <property name="text">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Arena Size&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+      </widget>
+      <widget class="QComboBox" name="unbounded_arena_size_combobox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="geometry">
+        <rect>
+         <x>125</x>
+         <y>95</y>
+         <width>71</width>
+         <height>27</height>
+        </rect>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">color: grey;
+border-color: grey;
+border: 1px solid grey; 
+padding: 1px 0px 1px 3px; /*This makes text colour work*/
+</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>15</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>20</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>25</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>30</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>35</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>40</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>45</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>50</string>
+        </property>
+       </item>
+      </widget>
      </widget>
-     <widget class="QLabel" name="label_5">
+     <widget class="QLabel" name="ground_texture_label">
       <property name="geometry">
        <rect>
         <x>20</x>
-        <y>190</y>
+        <y>180</y>
         <width>111</width>
         <height>20</height>
        </rect>
@@ -559,9 +935,9 @@ border-color: rgb(255, 255, 255);</string>
      <widget class="QComboBox" name="texture_combobox">
       <property name="geometry">
        <rect>
-        <x>150</x>
-        <y>190</y>
-        <width>131</width>
+        <x>140</x>
+        <y>180</y>
+        <width>121</width>
         <height>27</height>
        </rect>
       </property>
@@ -591,14 +967,16 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
      <widget class="QLabel" name="custom_world_path">
       <property name="geometry">
        <rect>
-        <x>68</x>
-        <y>162</y>
-        <width>200</width>
+        <x>58</x>
+        <y>140</y>
+        <width>203</width>
         <height>20</height>
        </rect>
       </property>
       <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
+       <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
       </property>
       <property name="text">
        <string/>
@@ -611,7 +989,7 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
       <property name="geometry">
        <rect>
         <x>20</x>
-        <y>230</y>
+        <y>220</y>
         <width>181</width>
         <height>22</height>
        </rect>
@@ -632,9 +1010,9 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
       </property>
       <property name="geometry">
        <rect>
-        <x>210</x>
-        <y>230</y>
-        <width>71</width>
+        <x>200</x>
+        <y>220</y>
+        <width>61</width>
         <height>27</height>
        </rect>
       </property>
@@ -680,17 +1058,27 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
         <string>6</string>
        </property>
       </item>
+      <item>
+       <property name="text">
+        <string>7</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>8</string>
+       </property>
+      </item>
      </widget>
-     <widget class="QComboBox" name="simulation_timer_combo_box">
+     <widget class="QComboBox" name="simulation_timer_combobox">
       <property name="enabled">
        <bool>true</bool>
       </property>
       <property name="geometry">
        <rect>
         <x>150</x>
-        <y>270</y>
-        <width>131</width>
-        <height>23</height>
+        <y>260</y>
+        <width>111</width>
+        <height>27</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -730,6 +1118,11 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
       </item>
       <item>
        <property name="text">
+        <string>20 min (Preliminary)</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
         <string>30 min (Preliminary)</string>
        </property>
       </item>
@@ -743,7 +1136,7 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
       <property name="geometry">
        <rect>
         <x>20</x>
-        <y>270</y>
+        <y>260</y>
         <width>130</width>
         <height>20</height>
        </rect>
@@ -758,340 +1151,217 @@ padding: 1px 0px 1px 3px; /*This makes text colour work*/
        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
      </widget>
+     <widget class="QCheckBox" name="create_savable_world_checkbox">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>260</y>
+        <width>211</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When checked, a Gazebo world without rovers, walls, ground texture, or a collection zone will be created. The purpose of this option is to generate tag distributions using the Uniform, Clustered, or Power Law in a way that you can save the world file from Gazebo and re-use that same distribution later using the Custom world option. It will also load much faster as well when loading a pre-built distribution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="whatsThis">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;When checked, a Gazebo world without rovers, walls, ground texture, or a collection zone will be created. The purpose of this option is to generate tag distributions using the Uniform, Clustered, or Power Law in a way that you can save the world file from Gazebo and re-use that same distribution later using the Custom world option. It will also load much faster as well when loading a pre-built distribution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Create Savable Gazebo World</string>
+      </property>
+      <property name="checked">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QComboBox" name="number_of_tags_combobox">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>55</y>
+        <width>131</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string notr="true">&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;The number of april tag cubes generated by the Uniform or Clustered distributions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="whatsThis">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of april tag cubes generated by the Uniform or Clustered distributions.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: grey;
+border-color: grey;
+border: 1px solid grey; 
+padding: 1px 0px 1px 3px; /*This makes text colour work*/
+</string>
+      </property>
+      <item>
+       <property name="text">
+        <string>256</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>128</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>64</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>32</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>16</string>
+       </property>
+      </item>
+      <item>
+       <property name="text">
+        <string>0</string>
+       </property>
+      </item>
+     </widget>
+     <widget class="QLabel" name="number_of_tags_label">
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>35</y>
+        <width>121</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: grey;</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;Number of Cubes&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="number_of_tags_label_2">
+      <property name="geometry">
+       <rect>
+        <x>280</x>
+        <y>80</y>
+        <width>231</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;*not available for Power Law or Custom World&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
+     </widget>
+     <zorder>round_type_button_group</zorder>
+     <zorder>target_distribution_group_box</zorder>
+     <zorder>custom_world_path_button</zorder>
+     <zorder>ground_texture_label</zorder>
+     <zorder>texture_combobox</zorder>
+     <zorder>custom_world_path</zorder>
+     <zorder>override_num_rovers_checkbox</zorder>
+     <zorder>custom_num_rovers_combobox</zorder>
+     <zorder>simulation_timer_combobox</zorder>
+     <zorder>simulation_timer_label</zorder>
+     <zorder>create_savable_world_checkbox</zorder>
+     <zorder>number_of_tags_label</zorder>
+     <zorder>number_of_tags_label_2</zorder>
+     <zorder>number_of_tags_combobox</zorder>
     </widget>
     <widget class="QLabel" name="label_7">
      <property name="geometry">
       <rect>
-       <x>80</x>
-       <y>50</y>
-       <width>121</width>
+       <x>205</x>
+       <y>10</y>
+       <width>140</width>
        <height>20</height>
       </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
      </property>
      <property name="text">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Simulation Setup&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-    </widget>
-    <widget class="QLabel" name="rover_image_label">
-     <property name="geometry">
-      <rect>
-       <x>290</x>
-       <y>20</y>
-       <width>501</width>
-       <height>427</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="pixmap">
-      <pixmap>../resources/rover.png</pixmap>
-     </property>
-    </widget>
-    <widget class="QPushButton" name="build_simulation_button">
-     <property name="geometry">
-      <rect>
-       <x>80</x>
-       <y>370</y>
-       <width>161</width>
-       <height>27</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);
-border-color: rgb(255, 255, 255);
-border: 1px solid white; 
-</string>
-     </property>
-     <property name="text">
-      <string>Build Simulation</string>
-     </property>
-    </widget>
-    <widget class="QFrame" name="frame_2">
-     <property name="geometry">
-      <rect>
-       <x>510</x>
-       <y>330</y>
-       <width>191</width>
-       <height>161</height>
-      </rect>
-     </property>
-     <property name="frameShape">
-      <enum>QFrame::StyledPanel</enum>
-     </property>
-     <property name="frameShadow">
-      <enum>QFrame::Raised</enum>
-     </property>
-     <widget class="QLabel" name="label_39">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>10</y>
-        <width>71</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Horz. Res</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_40">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>70</y>
-        <width>71</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Min Ang.</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_41">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>90</y>
-        <width>71</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Max Ang.</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_42">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>50</y>
-        <width>71</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Max</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_43">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>30</y>
-        <width>71</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Min</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_44">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>110</y>
-        <width>131</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Range Resolution</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_range_res">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>110</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_max_angle">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>90</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_min_angle">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>70</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_max">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>50</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_min">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>30</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_horz_res">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>10</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="label_65">
-      <property name="geometry">
-       <rect>
-        <x>10</x>
-        <y>130</y>
-        <width>121</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>Gaussian Noise</string>
-      </property>
-     </widget>
-     <widget class="QLabel" name="sonar_gaussian_noise">
-      <property name="geometry">
-       <rect>
-        <x>140</x>
-        <y>130</y>
-        <width>41</width>
-        <height>17</height>
-       </rect>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">color: rgb(255, 255, 255);</string>
-      </property>
-      <property name="text">
-       <string>val</string>
-      </property>
-     </widget>
-    </widget>
-    <widget class="QPushButton" name="clear_simulation_button">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="geometry">
-      <rect>
-       <x>80</x>
-       <y>400</y>
-       <width>161</width>
-       <height>27</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);
-border-color: rgb(255, 255, 255);
-border: 1px solid white; 
-</string>
-     </property>
-     <property name="text">
-      <string>End Simulation</string>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
      </property>
     </widget>
     <widget class="QLabel" name="label_11">
      <property name="geometry">
       <rect>
-       <x>360</x>
-       <y>310</y>
-       <width>31</width>
-       <height>17</height>
+       <x>220</x>
+       <y>340</y>
+       <width>40</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
      </property>
      <property name="text">
       <string>GPS</string>
      </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
     </widget>
-    <widget class="QFrame" name="frame_4">
+    <widget class="QFrame" name="GPS_frame">
      <property name="geometry">
       <rect>
-       <x>350</x>
-       <y>320</y>
-       <width>151</width>
-       <height>181</height>
+       <x>200</x>
+       <y>350</y>
+       <width>201</width>
+       <height>141</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -1104,10 +1374,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>30</y>
+        <y>25</y>
         <width>61</width>
-        <height>17</height>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1122,8 +1397,13 @@ border: 1px solid white;
         <x>10</x>
         <y>10</y>
         <width>61</width>
-        <height>17</height>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1136,10 +1416,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>50</y>
-        <width>71</width>
-        <height>17</height>
+        <y>40</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1152,10 +1437,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>70</y>
-        <width>71</width>
-        <height>17</height>
+        <y>55</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1167,11 +1457,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_update_rate">
       <property name="geometry">
        <rect>
-        <x>90</x>
+        <x>79</x>
         <y>10</y>
-        <width>51</width>
-        <height>17</height>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1183,11 +1478,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_ref_lat">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>30</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>25</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1199,11 +1499,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_ref_long">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>50</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>40</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1215,11 +1520,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_ref_heading">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>70</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>55</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1232,10 +1542,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>110</y>
-        <width>71</width>
-        <height>17</height>
+        <y>85</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1248,10 +1563,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>130</y>
-        <width>71</width>
-        <height>17</height>
+        <y>100</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1264,10 +1584,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>150</y>
-        <width>71</width>
-        <height>17</height>
+        <y>115</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1279,11 +1604,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_drift">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>110</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>85</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1295,11 +1625,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_drift_freq">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>130</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>100</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1311,11 +1646,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_noise">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>150</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>115</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1328,10 +1668,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>90</y>
-        <width>71</width>
-        <height>17</height>
+        <y>70</y>
+        <width>61</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1343,11 +1688,16 @@ border: 1px solid white;
      <widget class="QLabel" name="gps_ref_alt">
       <property name="geometry">
        <rect>
-        <x>90</x>
-        <y>90</y>
-        <width>51</width>
-        <height>17</height>
+        <x>79</x>
+        <y>70</y>
+        <width>111</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1357,29 +1707,13 @@ border: 1px solid white;
       </property>
      </widget>
     </widget>
-    <widget class="QLabel" name="label_12">
+    <widget class="QFrame" name="IMU_frame">
      <property name="geometry">
       <rect>
-       <x>360</x>
-       <y>130</y>
-       <width>31</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
-     </property>
-     <property name="text">
-      <string>IMU</string>
-     </property>
-    </widget>
-    <widget class="QFrame" name="frame_5">
-     <property name="geometry">
-      <rect>
-       <x>350</x>
-       <y>140</y>
-       <width>271</width>
-       <height>171</height>
+       <x>410</x>
+       <y>350</y>
+       <width>341</width>
+       <height>141</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -1391,11 +1725,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_27">
       <property name="geometry">
        <rect>
-        <x>130</x>
+        <x>170</x>
         <y>10</y>
-        <width>61</width>
-        <height>17</height>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1408,10 +1747,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>30</y>
-        <width>91</width>
-        <height>17</height>
+        <y>25</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1424,10 +1768,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>50</y>
-        <width>61</width>
-        <height>17</height>
+        <y>40</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1440,10 +1789,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>100</y>
-        <width>81</width>
-        <height>17</height>
+        <y>75</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1455,11 +1809,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_31">
       <property name="geometry">
        <rect>
-        <x>130</x>
-        <y>30</y>
-        <width>91</width>
-        <height>17</height>
+        <x>170</x>
+        <y>25</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1471,11 +1830,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_32">
       <property name="geometry">
        <rect>
-        <x>130</x>
-        <y>50</y>
-        <width>91</width>
-        <height>17</height>
+        <x>170</x>
+        <y>40</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1489,9 +1853,14 @@ border: 1px solid white;
        <rect>
         <x>10</x>
         <y>10</y>
-        <width>61</width>
-        <height>17</height>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1503,11 +1872,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_34">
       <property name="geometry">
        <rect>
-        <x>130</x>
-        <y>100</y>
-        <width>91</width>
-        <height>17</height>
+        <x>170</x>
+        <y>75</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1519,11 +1893,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_35">
       <property name="geometry">
        <rect>
-        <x>130</x>
-        <y>120</y>
-        <width>91</width>
-        <height>17</height>
+        <x>170</x>
+        <y>90</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1535,11 +1914,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_36">
       <property name="geometry">
        <rect>
-        <x>130</x>
-        <y>80</y>
-        <width>91</width>
-        <height>17</height>
+        <x>170</x>
+        <y>60</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1552,10 +1936,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>80</y>
-        <width>81</width>
-        <height>17</height>
+        <y>60</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1568,10 +1957,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>130</y>
-        <width>81</width>
-        <height>17</height>
+        <y>95</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1583,11 +1977,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_update_rate">
       <property name="geometry">
        <rect>
-        <x>180</x>
+        <x>240</x>
         <y>10</y>
-        <width>41</width>
-        <height>17</height>
+        <width>90</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1599,11 +1998,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_rate_drift">
       <property name="geometry">
        <rect>
-        <x>220</x>
-        <y>30</y>
-        <width>41</width>
-        <height>17</height>
+        <x>240</x>
+        <y>25</y>
+        <width>90</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1615,11 +2019,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_rate_noise">
       <property name="geometry">
        <rect>
-        <x>220</x>
-        <y>50</y>
-        <width>41</width>
-        <height>17</height>
+        <x>240</x>
+        <y>40</y>
+        <width>90</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1631,11 +2040,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_heading_drift">
       <property name="geometry">
        <rect>
-        <x>220</x>
-        <y>100</y>
-        <width>41</width>
-        <height>17</height>
+        <x>240</x>
+        <y>75</y>
+        <width>90</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1647,11 +2061,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_heading_noise">
       <property name="geometry">
        <rect>
-        <x>180</x>
-        <y>120</y>
-        <width>41</width>
-        <height>17</height>
+        <x>240</x>
+        <y>90</y>
+        <width>90</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1663,11 +2082,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_accel_drift">
       <property name="geometry">
        <rect>
-        <x>60</x>
-        <y>30</y>
-        <width>41</width>
+        <x>80</x>
+        <y>25</y>
+        <width>85</width>
         <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1679,11 +2103,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_accel_noise">
       <property name="geometry">
        <rect>
-        <x>60</x>
-        <y>50</y>
-        <width>41</width>
+        <x>80</x>
+        <y>40</y>
+        <width>85</width>
         <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1695,11 +2124,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_rpy_offsets">
       <property name="geometry">
        <rect>
-        <x>70</x>
-        <y>100</y>
-        <width>41</width>
-        <height>17</height>
+        <x>80</x>
+        <y>75</y>
+        <width>85</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1711,11 +2145,16 @@ border: 1px solid white;
      <widget class="QLabel" name="imu_noise">
       <property name="geometry">
        <rect>
-        <x>70</x>
-        <y>130</y>
-        <width>51</width>
-        <height>17</height>
+        <x>80</x>
+        <y>95</y>
+        <width>85</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1727,27 +2166,40 @@ border: 1px solid white;
      <widget class="QLabel" name="label_63">
       <property name="geometry">
        <rect>
-        <x>20</x>
-        <y>150</y>
-        <width>151</width>
-        <height>17</height>
+        <x>10</x>
+        <y>110</y>
+        <width>60</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="toolTip">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Magnetic Declination&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
       <property name="text">
-       <string>Magnetic Declination</string>
+       <string>Mag. Dec.</string>
       </property>
      </widget>
      <widget class="QLabel" name="label_64">
       <property name="geometry">
        <rect>
-        <x>180</x>
-        <y>150</y>
-        <width>51</width>
-        <height>17</height>
+        <x>80</x>
+        <y>110</y>
+        <width>85</width>
+        <height>16</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1757,28 +2209,12 @@ border: 1px solid white;
       </property>
      </widget>
     </widget>
-    <widget class="QLabel" name="label_17">
+    <widget class="QFrame" name="camera_frame_status">
      <property name="geometry">
       <rect>
-       <x>520</x>
-       <y>0</y>
-       <width>51</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
-     </property>
-     <property name="text">
-      <string>Camera</string>
-     </property>
-    </widget>
-    <widget class="QFrame" name="frame_6">
-     <property name="geometry">
-      <rect>
-       <x>510</x>
-       <y>10</y>
-       <width>151</width>
+       <x>560</x>
+       <y>20</y>
+       <width>191</width>
        <height>131</height>
       </rect>
      </property>
@@ -1792,10 +2228,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>10</y>
+        <y>15</y>
         <width>61</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1808,10 +2249,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>30</y>
+        <y>35</y>
         <width>61</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1829,6 +2275,11 @@ border: 1px solid white;
         <height>17</height>
        </rect>
       </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
       </property>
@@ -1840,10 +2291,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>70</y>
+        <y>65</y>
         <width>61</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1855,11 +2311,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_update_rate">
       <property name="geometry">
        <rect>
-        <x>80</x>
-        <y>10</y>
-        <width>51</width>
+        <x>120</x>
+        <y>15</y>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1871,11 +2332,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_width">
       <property name="geometry">
        <rect>
-        <x>80</x>
-        <y>30</y>
-        <width>51</width>
+        <x>120</x>
+        <y>35</y>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1887,11 +2353,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_height">
       <property name="geometry">
        <rect>
-        <x>80</x>
+        <x>120</x>
         <y>50</y>
-        <width>51</width>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1903,11 +2374,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_format">
       <property name="geometry">
        <rect>
-        <x>80</x>
-        <y>70</y>
-        <width>51</width>
+        <x>120</x>
+        <y>65</y>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1920,10 +2396,15 @@ border: 1px solid white;
       <property name="geometry">
        <rect>
         <x>10</x>
-        <y>90</y>
+        <y>85</y>
         <width>81</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1935,11 +2416,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_noise_mean">
       <property name="geometry">
        <rect>
-        <x>100</x>
-        <y>90</y>
-        <width>41</width>
+        <x>120</x>
+        <y>85</y>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1951,11 +2437,16 @@ border: 1px solid white;
      <widget class="QLabel" name="label_45">
       <property name="geometry">
        <rect>
-        <x>50</x>
-        <y>110</y>
+        <x>47</x>
+        <y>100</y>
         <width>41</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1967,11 +2458,16 @@ border: 1px solid white;
      <widget class="QLabel" name="camera_noise_stdev">
       <property name="geometry">
        <rect>
-        <x>100</x>
-        <y>110</y>
-        <width>41</width>
+        <x>120</x>
+        <y>100</y>
+        <width>60</width>
         <height>17</height>
        </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
       </property>
       <property name="styleSheet">
        <string notr="true">color: rgb(255, 255, 255);</string>
@@ -1993,238 +2489,13 @@ border: 1px solid white;
      <zorder>label_45</zorder>
      <zorder>camera_noise_stdev</zorder>
     </widget>
-    <widget class="QPushButton" name="visualize_simulation_button">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
+    <widget class="QFrame" name="ultrasound_frame">
      <property name="geometry">
       <rect>
-       <x>80</x>
-       <y>430</y>
-       <width>161</width>
-       <height>27</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);
-border-color: rgb(255, 255, 255);
-border: 1px solid white; 
-</string>
-     </property>
-     <property name="text">
-      <string>Toggle Visualization</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_10">
-     <property name="geometry">
-      <rect>
-       <x>520</x>
-       <y>320</y>
-       <width>81</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="styleSheet">
-      <string notr="true">color: rgb(255, 255, 255);</string>
-     </property>
-     <property name="text">
-      <string>Ultrasound</string>
-     </property>
-    </widget>
-    <zorder>rover_image_label</zorder>
-    <zorder>setup_group</zorder>
-    <zorder>label_7</zorder>
-    <zorder>build_simulation_button</zorder>
-    <zorder>frame_2</zorder>
-    <zorder>clear_simulation_button</zorder>
-    <zorder>frame_4</zorder>
-    <zorder>label_11</zorder>
-    <zorder>frame_5</zorder>
-    <zorder>label_12</zorder>
-    <zorder>frame_6</zorder>
-    <zorder>label_17</zorder>
-    <zorder>visualize_simulation_button</zorder>
-    <zorder>label_10</zorder>
-   </widget>
-   <widget class="QWidget" name="stats_tab">
-    <attribute name="title">
-     <string>Task Status</string>
-    </attribute>
-    <widget class="QLabel" name="label_6">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>60</y>
-       <width>201</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Number of Targets Detected:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="num_targets_detected_label">
-     <property name="geometry">
-      <rect>
-       <x>310</x>
-       <y>60</y>
-       <width>67</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_8">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>90</y>
-       <width>201</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Number of Targets Collected:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="num_targets_collected_label">
-     <property name="geometry">
-      <rect>
-       <x>310</x>
-       <y>90</y>
-       <width>67</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="label_9">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>150</y>
-       <width>181</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Obstacle Avoidance Calls:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="perc_of_time_avoiding_obstacles">
-     <property name="geometry">
-      <rect>
-       <x>310</x>
-       <y>150</y>
-       <width>67</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="currentSimulationTimeLabel">
-     <property name="geometry">
-      <rect>
-       <x>210</x>
-       <y>250</y>
-       <width>250</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="simulationTimerStartLabel">
-     <property name="geometry">
-      <rect>
-       <x>210</x>
-       <y>280</y>
-       <width>250</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="simulationTimerStopLabel">
-     <property name="geometry">
-      <rect>
-       <x>210</x>
-       <y>310</y>
-       <width>250</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-    <widget class="QLabel" name="currentSimulationTimeTitle">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>250</y>
-       <width>100</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Current Time:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="simulationTimerStartTitle">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>280</y>
-       <width>100</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Timer Start:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QLabel" name="simulationTimerStopTitle">
-     <property name="geometry">
-      <rect>
-       <x>100</x>
-       <y>310</y>
-       <width>100</width>
-       <height>17</height>
-      </rect>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Timer Stop:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-    <widget class="QFrame" name="Simulation_Timer_Frame">
-     <property name="enabled">
-      <bool>true</bool>
-     </property>
-     <property name="geometry">
-      <rect>
-       <x>90</x>
-       <y>220</y>
-       <width>400</width>
-       <height>120</height>
+       <x>560</x>
+       <y>170</y>
+       <width>191</width>
+       <height>161</height>
       </rect>
      </property>
      <property name="frameShape">
@@ -2233,14 +2504,308 @@ border: 1px solid white;
      <property name="frameShadow">
       <enum>QFrame::Raised</enum>
      </property>
+     <widget class="QLabel" name="label_39">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>71</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Horz. Res</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_40">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>70</y>
+        <width>71</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Min Ang.</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_41">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>90</y>
+        <width>71</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Max Ang.</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_42">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>50</y>
+        <width>71</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Max</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_43">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>71</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Min</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_44">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>110</y>
+        <width>131</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Range Resolution</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_range_res">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>110</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_max_angle">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>90</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_min_angle">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>70</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_max">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>50</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_min">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>30</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_horz_res">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>10</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_65">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>130</y>
+        <width>121</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>Gaussian Noise</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="sonar_gaussian_noise">
+      <property name="geometry">
+       <rect>
+        <x>120</x>
+        <y>130</y>
+        <width>60</width>
+        <height>17</height>
+       </rect>
+      </property>
+      <property name="font">
+       <font>
+        <pointsize>10</pointsize>
+       </font>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>val</string>
+      </property>
+     </widget>
     </widget>
-    <widget class="QLabel" name="simulation_timer_frame_label">
+    <widget class="QLabel" name="label_10">
      <property name="geometry">
       <rect>
-       <x>100</x>
-       <y>210</y>
-       <width>310</width>
-       <height>25</height>
+       <x>580</x>
+       <y>160</y>
+       <width>90</width>
+       <height>20</height>
       </rect>
      </property>
      <property name="styleSheet">
@@ -2249,26 +2814,213 @@ border: 1px solid white;
 padding: 1px;</string>
      </property>
      <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Simulation Timer (for simulated rovers only)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      <string>Ultrasound</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
      </property>
     </widget>
-    <zorder>Simulation_Timer_Frame</zorder>
-    <zorder>label_6</zorder>
-    <zorder>num_targets_detected_label</zorder>
-    <zorder>label_8</zorder>
-    <zorder>num_targets_collected_label</zorder>
-    <zorder>label_9</zorder>
-    <zorder>perc_of_time_avoiding_obstacles</zorder>
-    <zorder>currentSimulationTimeLabel</zorder>
-    <zorder>simulationTimerStartLabel</zorder>
-    <zorder>simulationTimerStopLabel</zorder>
-    <zorder>currentSimulationTimeTitle</zorder>
-    <zorder>simulationTimerStartTitle</zorder>
-    <zorder>simulationTimerStopTitle</zorder>
-    <zorder>simulation_timer_frame_label</zorder>
+    <widget class="QLabel" name="label_12">
+     <property name="geometry">
+      <rect>
+       <x>430</x>
+       <y>340</y>
+       <width>40</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
+     </property>
+     <property name="text">
+      <string>IMU</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QLabel" name="label_17">
+     <property name="geometry">
+      <rect>
+       <x>580</x>
+       <y>10</y>
+       <width>65</width>
+       <height>20</height>
+      </rect>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
+     </property>
+     <property name="text">
+      <string>Camera</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+    <widget class="QFrame" name="button_frame">
+     <property name="geometry">
+      <rect>
+       <x>10</x>
+       <y>350</y>
+       <width>181</width>
+       <height>141</height>
+      </rect>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="QCheckBox" name="start_visualization_on_build_checkbox">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>30</x>
+        <y>105</y>
+        <width>21</width>
+        <height>22</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>16777215</width>
+        <height>22</height>
+       </size>
+      </property>
+      <property name="toolTip">
+       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;When checked, a Gazebo world without rovers, walls, ground texture, or a collection zone will be created. The purpose of this option is to generate tag distributions using the Uniform, Clustered, or Power Law in a way that you can save the world file from Gazebo and re-use that same distribution later using the Custom world option. It will also load much faster as well when loading a pre-built distribution.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="whatsThis">
+       <string/>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string/>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QLabel" name="start_visualization_on_build_label">
+      <property name="geometry">
+       <rect>
+        <x>55</x>
+        <y>100</y>
+        <width>91</width>
+        <height>31</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);</string>
+      </property>
+      <property name="text">
+       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p align=&quot;center&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Start Visualization On Build&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+      <property name="indent">
+       <number>0</number>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="build_simulation_button">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>161</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);
+border-color: rgb(255, 255, 255);
+border: 1px solid white; 
+</string>
+      </property>
+      <property name="text">
+       <string>Build Simulation</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="clear_simulation_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>40</y>
+        <width>161</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);
+border-color: rgb(255, 255, 255);
+border: 1px solid white; 
+</string>
+      </property>
+      <property name="text">
+       <string>End Simulation</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="visualize_simulation_button">
+      <property name="enabled">
+       <bool>true</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>70</y>
+        <width>161</width>
+        <height>27</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">color: rgb(255, 255, 255);
+border-color: rgb(255, 255, 255);
+border: 1px solid white; 
+</string>
+      </property>
+      <property name="text">
+       <string>Toggle Visualization</string>
+      </property>
+     </widget>
+    </widget>
+    <zorder>button_frame</zorder>
+    <zorder>setup_group</zorder>
+    <zorder>label_7</zorder>
+    <zorder>GPS_frame</zorder>
+    <zorder>label_11</zorder>
+    <zorder>IMU_frame</zorder>
+    <zorder>camera_frame_status</zorder>
+    <zorder>ultrasound_frame</zorder>
+    <zorder>label_10</zorder>
+    <zorder>label_12</zorder>
+    <zorder>label_17</zorder>
    </widget>
   </widget>
   <widget class="QFrame" name="control_frame">
@@ -2277,10 +3029,10 @@ padding: 1px;</string>
    </property>
    <property name="geometry">
     <rect>
-     <x>600</x>
-     <y>560</y>
-     <width>201</width>
-     <height>141</height>
+     <x>650</x>
+     <y>547</y>
+     <width>211</width>
+     <height>163</height>
     </rect>
    </property>
    <property name="frameShape">
@@ -2292,10 +3044,10 @@ padding: 1px;</string>
    <widget class="QGroupBox" name="control_group_box">
     <property name="geometry">
      <rect>
-      <x>10</x>
+      <x>24</x>
       <y>10</y>
-      <width>181</width>
-      <height>121</height>
+      <width>161</width>
+      <height>141</height>
      </rect>
     </property>
     <property name="styleSheet">
@@ -2311,8 +3063,8 @@ padding: 1px;</string>
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>40</y>
-       <width>171</width>
+       <y>50</y>
+       <width>121</width>
        <height>30</height>
       </rect>
      </property>
@@ -2333,7 +3085,7 @@ padding: 1px;</string>
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>25</y>
+       <y>30</y>
        <width>117</width>
        <height>20</height>
       </rect>
@@ -2358,7 +3110,7 @@ padding: 1px;</string>
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>95</y>
+       <y>110</y>
        <width>150</width>
        <height>22</height>
       </rect>
@@ -2380,7 +3132,7 @@ border: 1px solid white;
      <property name="geometry">
       <rect>
        <x>10</x>
-       <y>70</y>
+       <y>85</y>
        <width>150</width>
        <height>22</height>
       </rect>
@@ -2400,10 +3152,10 @@ border: 1px solid white;
   <widget class="QFrame" name="joystick_frame">
    <property name="geometry">
     <rect>
-     <x>810</x>
-     <y>590</y>
-     <width>191</width>
-     <height>111</height>
+     <x>870</x>
+     <y>547</y>
+     <width>211</width>
+     <height>163</height>
     </rect>
    </property>
    <property name="frameShape">
@@ -2415,8 +3167,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_drive_forward">
     <property name="geometry">
      <rect>
-      <x>110</x>
-      <y>40</y>
+      <x>118</x>
+      <y>70</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2430,8 +3182,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_drive_left">
     <property name="geometry">
      <rect>
-      <x>90</x>
-      <y>60</y>
+      <x>98</x>
+      <y>90</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2445,8 +3197,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_drive_right">
     <property name="geometry">
      <rect>
-      <x>130</x>
-      <y>60</y>
+      <x>138</x>
+      <y>90</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2460,8 +3212,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_drive_back">
     <property name="geometry">
      <rect>
-      <x>110</x>
-      <y>80</y>
+      <x>118</x>
+      <y>110</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2475,8 +3227,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_gripper_up">
     <property name="geometry">
      <rect>
-      <x>30</x>
-      <y>40</y>
+      <x>24</x>
+      <y>70</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2490,8 +3242,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_gripper_open">
     <property name="geometry">
      <rect>
-      <x>50</x>
-      <y>60</y>
+      <x>44</x>
+      <y>90</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2505,8 +3257,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_gripper_close">
     <property name="geometry">
      <rect>
-      <x>10</x>
-      <y>60</y>
+      <x>5</x>
+      <y>90</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2520,8 +3272,8 @@ border: 1px solid white;
    <widget class="QLCDNumber" name="joy_lcd_gripper_down">
     <property name="geometry">
      <rect>
-      <x>30</x>
-      <y>80</y>
+      <x>24</x>
+      <y>110</y>
       <width>41</width>
       <height>16</height>
      </rect>
@@ -2535,10 +3287,10 @@ border: 1px solid white;
    <widget class="QLabel" name="drive_label">
     <property name="geometry">
      <rect>
-      <x>120</x>
-      <y>10</y>
-      <width>67</width>
-      <height>17</height>
+      <x>128</x>
+      <y>30</y>
+      <width>51</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="styleSheet">
@@ -2547,14 +3299,17 @@ border: 1px solid white;
     <property name="text">
      <string>Drive</string>
     </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
    </widget>
    <widget class="QLabel" name="gripper_label">
     <property name="geometry">
      <rect>
-      <x>40</x>
-      <y>10</y>
-      <width>67</width>
-      <height>17</height>
+      <x>20</x>
+      <y>30</y>
+      <width>81</width>
+      <height>20</height>
      </rect>
     </property>
     <property name="styleSheet">
@@ -2562,6 +3317,9 @@ border: 1px solid white;
     </property>
     <property name="text">
      <string>Gripper</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
     </property>
    </widget>
   </widget>
@@ -2630,26 +3388,13 @@ border: 1px solid white;
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;version&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
-  <widget class="QLabel" name="rover_name">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>330</y>
-     <width>191</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Not Connected&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-   </property>
-  </widget>
   <widget class="BWTabWidget" name="log_tab">
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>510</y>
-     <width>571</width>
-     <height>211</height>
+     <y>520</y>
+     <width>631</width>
+     <height>201</height>
     </rect>
    </property>
    <property name="styleSheet">
@@ -2708,7 +3453,7 @@ QTabBar::tab:only-one {
 </string>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="info_log_tab">
     <attribute name="title">
@@ -2719,8 +3464,8 @@ QTabBar::tab:only-one {
       <rect>
        <x>0</x>
        <y>0</y>
-       <width>561</width>
-       <height>171</height>
+       <width>631</width>
+       <height>161</height>
       </rect>
      </property>
     </widget>
@@ -2734,8 +3479,8 @@ QTabBar::tab:only-one {
       <rect>
        <x>0</x>
        <y>0</y>
-       <width>571</width>
-       <height>171</height>
+       <width>631</width>
+       <height>161</height>
       </rect>
      </property>
     </widget>
@@ -2840,25 +3585,381 @@ QTabBar::tab:only-one {
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-size:9pt; color:#ffffff;&quot;&gt;Map&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </widget>
-  <widget class="QLabel" name="gps_numSV_label">
+  <widget class="QFrame" name="Simulation_Timer_Frame">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="geometry">
     <rect>
      <x>10</x>
-     <y>360</y>
-     <width>191</width>
+     <y>404</y>
+     <width>311</width>
+     <height>101</height>
+    </rect>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::StyledPanel</enum>
+   </property>
+   <property name="frameShadow">
+    <enum>QFrame::Raised</enum>
+   </property>
+   <widget class="QLabel" name="currentSimulationTimeTitle">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>40</y>
+      <width>80</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Current Time:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="simulationTimerStartTitle">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>55</y>
+      <width>80</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Timer Start:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="simulationTimerStopTitle">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>70</y>
+      <width>80</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Timer Stop:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+    </property>
+   </widget>
+   <widget class="QLabel" name="currentSimulationTimeLabel">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>40</y>
+      <width>205</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="simulationTimerStartLabel">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>55</y>
+      <width>205</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="simulationTimerStopLabel">
+    <property name="geometry">
+     <rect>
+      <x>100</x>
+      <y>70</y>
+      <width>205</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;---&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_8">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>20</y>
+      <width>181</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Number of Targets Collected:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="num_targets_collected_label">
+    <property name="geometry">
+     <rect>
+      <x>192</x>
+      <y>20</y>
+      <width>110</width>
+      <height>15</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QLabel" name="simulation_timer_frame_label">
+   <property name="geometry">
+    <rect>
+     <x>29</x>
+     <y>394</y>
+     <width>271</width>
      <height>20</height>
     </rect>
    </property>
-   <property name="mouseTracking">
-    <bool>true</bool>
+   <property name="font">
+    <font>
+     <pointsize>10</pointsize>
+    </font>
    </property>
-   <property name="toolTip">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Displays the number of GPS Satellites detected by the selected physical rover. Simulated rovers will not display a value here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   <property name="styleSheet">
+    <string notr="true">color: white;
+border: 1px solid white;
+padding: 1px;</string>
    </property>
    <property name="text">
-    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Sim Timer And Status (simulated rovers only)&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+   <property name="alignment">
+    <set>Qt::AlignCenter</set>
    </property>
   </widget>
+  <widget class="QFrame" name="status_frame">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>300</y>
+     <width>311</width>
+     <height>81</height>
+    </rect>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::StyledPanel</enum>
+   </property>
+   <property name="frameShadow">
+    <enum>QFrame::Raised</enum>
+   </property>
+   <widget class="QLabel" name="rover_name">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>10</y>
+      <width>191</width>
+      <height>15</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Not Connected&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="gps_numSV_label">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>30</y>
+      <width>120</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="mouseTracking">
+     <bool>true</bool>
+    </property>
+    <property name="toolTip">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Displays the number of GPS Satellites detected by the selected physical rover. Simulated rovers will not display a value here.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 255);</string>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;---&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_9">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>50</y>
+      <width>150</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#fefefe;&quot;&gt;Obstacle Avoidance Calls:&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="perc_of_time_avoiding_obstacles">
+    <property name="geometry">
+     <rect>
+      <x>170</x>
+      <y>50</y>
+      <width>120</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;0&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="gps_numSV_title">
+    <property name="geometry">
+     <rect>
+      <x>10</x>
+      <y>30</y>
+      <width>150</width>
+      <height>16</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>10</pointsize>
+     </font>
+    </property>
+    <property name="styleSheet">
+     <string notr="true">color: rgb(255, 255, 255);</string>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Number of GPS Satellites:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QFrame" name="joystick_disabled_frame">
+   <property name="geometry">
+    <rect>
+     <x>870</x>
+     <y>547</y>
+     <width>211</width>
+     <height>163</height>
+    </rect>
+   </property>
+   <property name="frameShape">
+    <enum>QFrame::StyledPanel</enum>
+   </property>
+   <property name="frameShadow">
+    <enum>QFrame::Raised</enum>
+   </property>
+   <widget class="QLabel" name="auto_enabled_label">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>55</y>
+      <width>171</width>
+      <height>51</height>
+     </rect>
+    </property>
+    <property name="font">
+     <font>
+      <pointsize>12</pointsize>
+     </font>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ffffff;&quot;&gt;Autonomous Control Enabled&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+    <property name="alignment">
+     <set>Qt::AlignCenter</set>
+    </property>
+    <property name="wordWrap">
+     <bool>true</bool>
+    </property>
+   </widget>
+  </widget>
+  <zorder>joystick_disabled_frame</zorder>
+  <zorder>joystick_frame</zorder>
+  <zorder>tab_widget</zorder>
+  <zorder>control_frame</zorder>
+  <zorder>label</zorder>
+  <zorder>label_2</zorder>
+  <zorder>label_3</zorder>
+  <zorder>label_4</zorder>
+  <zorder>version_number_label</zorder>
+  <zorder>log_tab</zorder>
+  <zorder>Rover_frame</zorder>
+  <zorder>label_13</zorder>
+  <zorder>map_list_label</zorder>
+  <zorder>Simulation_Timer_Frame</zorder>
+  <zorder>simulation_timer_frame_label</zorder>
+  <zorder>status_frame</zorder>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
@@ -2897,6 +3998,5 @@ QTabBar::tab:only-one {
  <connections/>
  <buttongroups>
   <buttongroup name="rover_control_button_group"/>
-  <buttongroup name="map_display_button_group"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
First, a disclaimer and apology: the single massive commit is the
result of having to cherry pick the many apsects of this feature
from other branches that were merged or partially merged into the
now-deleted development branch.

That being said, there is a lot of really cool things in this feature:

- Unique Rover Colors: You can check this box on the sensor display
    tab to have reach rover's trail on the Map Frame be uniquely
    colored. There are 8 unique colors, if you are using more than
    8 rovers than the colors are assigned in a cycle. For example,
    rover 0 and rover 8 will be the same color, etc.

- Global Frame: You can check this box on the sensor display tab to
    reposition the Map Frame trails of all rovers to be as they appear
    in the Gazebo world. That is, the Map Frame displays all rovers
    at (0,0) by default from their Odometry frame of reference. This
    check box corrects that by offsetting their trails by their
    Gazebo spawn points. Unfortunately, this is for simulated rovers
    only at this time.

- Savable Gazebo World: You can check this box on the simulation control
    tab to build a simulation's Gazebo world without rovers, walls,
    ground texture, or a collection zone will be created. The purpose of
    this option is to generate tag distributions using the Uniform,
    Clustered, or Power Law in a way that you can save the world file from
    Gazebo and re-use that same distribution later using the Custom world
    option. It will also load much faster as well when loading a pre-built
    distribution.

- Unbounded Round Type: In addition to Preliminary and Final, you can now
    select the "unbounded" round type which has no barrier walls. When
    selected, you can also choose the square arena size from the accompanying
    drop down menu. When creating target distributions using Uniform,
    Clustered, or Power Law, the apriltag cubes will be spread out to fill
    the size of the arena you chose.

- Number of Cubes: When building worlds with the Uniform or Clustered
    distributions, you can set the total number of cubes generated in
    the simulation control tab. The sizes of clusters are scaled based
    on the total amount of cubes selected. This is useful for building
    worlds with smaller number of cubes for testing without having to
    wait for a long time for the placement of many cubes.

- Simulation Length Timer: There is now an option for a 20 minute timer
    in the Simulation Length timer drop down box.

- Start Visualization On Build: There is now a checkbox that toggles whether
    or not Gazebo is launched immediately when you click the Build Simulation
    button. When unchecked, you must click Toggle Visualization to launch
    Gazebo for your currently running simulation.

- The Task Status tab has been removed: The information previously kept
    in this tab has been moved to the left hand side of the GUI screen
    and is accessible while in both of the other tabs.

- Overall streamlining and beautification(*) of the GUI: There was a lot of
    unused and awkward white space that was condensed and re-allocated so
    that the maximum amount of useful information was available in each
    tab of the RQT GUI.

(*) Based on the writer's biased opinion, grid based layouts are pretty.

![screenshot from 2017-10-01 21-36-23](https://user-images.githubusercontent.com/7574554/31063507-bf0d79e8-a6f0-11e7-9953-12f799cb4dbe.png)
![screenshot from 2017-10-01 21-36-05](https://user-images.githubusercontent.com/7574554/31063508-bf0f40d4-a6f0-11e7-9bbf-f4f32c5ab230.png)