### PR TITLE
Bug fix: infolog messages from popout map not displayed

### DIFF
--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -73,6 +73,9 @@ void MapFrame::createPopoutWindow( MapData * map_data )
   popout_window->setCentralWidget(central_widget);
 
   connect(this, SIGNAL(delayedUpdate()), popout_mapframe, SLOT(update()), Qt::QueuedConnection);
+
+  // Forward info messages from the popout framt to the rover gui via the signal in this parent map frame
+  connect(popout_mapframe, SIGNAL(sendInfoLogMessage(QString)), this, SIGNAL(sendInfoLogMessage(QString)));
 }
 
 void MapFrame::paintEvent(QPaintEvent* event) {
@@ -879,7 +882,6 @@ void MapFrame::receiveCurrentRoverName( QString rover_name )
 {
   this->rover_currently_selected = rover_name.toStdString();
 }
-
 
 MapFrame::~MapFrame()
 {


### PR DESCRIPTION
Messages sent from the popout map were not displayed in the GUI info text region. The info log signal from popout_mapframe was not connected to the rover GUI receive info log slot.

The fix was to connect the popout_mapframe signal to the parent mapframe signal. This forwards the info log messages from the popout frame to the parent frame and on to the rover GUI.