### PR TITLE
Fixed manual driving controle for physical rovers

### DIFF
--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -165,16 +165,6 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   // the hardware to fail when the robot moves itself too violently.
   int max_motor_cmd = 120;
 
-  if (currentMode == 1)
-  {
-    // Assumes left and right are always between -1 and 1
-    float linear = left * max_motor_cmd; 
-    float angular = right * max_motor_cmd; 
-
-    left = linear - angular;
-    right = linear + angular;
-  }
-
   // Check that the resulting motor commands do not exceed the specified safe maximum value
   if (left > max_motor_cmd)
   {


### PR DESCRIPTION
A previous update to joystick control brought its output in line with auto mode
This causes the special case in abridge to no longer be needed.

fixes issue #74 