### PR TITLE
Don't crash on close when popout map is open

### DIFF
--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -509,7 +509,10 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     else painter.setPen(Qt::yellow);
     
     pair<float,float> current_coordinate;
-    current_coordinate = map_data->getEKFPath(rover_to_display)->back();
+    if(! map_data->getEKFPath(rover_to_display)->empty() )
+    {
+       current_coordinate = map_data->getEKFPath(rover_to_display)->back();
+    }
     
     float x = map_origin_x+((current_coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
     float y = map_origin_y+((current_coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);


### PR DESCRIPTION
Resolves issue #71 by guarding against empty path lists

This is something that is done implicitly and explicitly throughout
the code, and is necessary here to ensure that we don't try to draw
anything after the map data is cleared on destruction of the gui.