### PR TITLE
Updated deploy script to initialize and update submodules

### DIFF
--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -27,11 +27,11 @@ Check()
 
 	if [ -z "$(ls -A $dirPath/src/ublox/)" ]; then
 		echo "The ublox submodule is missing."
-                cd $dirPath; #Entering directory/local git repo (needed to run git commands)
-		echo "Initiliazing and updating ublox and april tag submodules...";		
+		cd $dirPath; #Entering directory/local git repo (needed to run git commands)
+		echo "Initiliazing and updating ublox and april tag submodules...";
 		git submodule init;                
 		git submodule update; 
-                exit 1;
+		exit 1;
 	fi
 
 	if [ -z "$(ls -A $dirPath/src/apriltags_ros/)" ]; then

--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -25,18 +25,12 @@ Check()
 {
 	cd ~
 
-	if [ -z "$(ls -A $dirPath/src/ublox/)" ]; then
-		echo "The ublox submodule is missing."
+	if [ [-z "$(ls -A $dirPath/src/ublox/)"] || [-z "$(ls -A $dirPath/src/apriltags_ros/)"] ]; then
+		echo "The ublox and/or april tags submodule is missing."
 		cd $dirPath; #Entering directory/local git repo (needed to run git commands)
 		echo "Initiliazing and updating ublox and april tag submodules...";
 		git submodule init;                
 		git submodule update; 
-		exit 1;
-	fi
-
-	if [ -z "$(ls -A $dirPath/src/apriltags_ros/)" ]; then
-  		echo "The apriltags submodule is missing."
-  		exit 1
 	fi
 }
 

--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -26,8 +26,12 @@ Check()
 	cd ~
 
 	if [ -z "$(ls -A $dirPath/src/ublox/)" ]; then
-  		echo "The ublox submodule is missing."
-  		exit 1
+		echo "The ublox submodule is missing."
+                cd $dirPath; #Entering directory/local git repo (needed to run git commands)
+		echo "Initiliazing and updating ublox and april tag submodules...";		
+		git submodule init;                
+		git submodule update; 
+                exit 1;
 	fi
 
 	if [ -z "$(ls -A $dirPath/src/apriltags_ros/)" ]; then


### PR DESCRIPTION
The problem wasn't actually with nested directories. The issue came from missing ublox and april tag submodules. This pull request checks to see if the ublox or april tag submodules are present. If not, it will initialize and update them both. It will then continue with the rest of the script, rather than terminate.