### PR TITLE
Bug fix: swarmie message dependency declarations missing

### DIFF
--- a/src/behaviours/CMakeLists.txt
+++ b/src/behaviours/CMakeLists.txt
@@ -11,7 +11,8 @@ find_package(catkin REQUIRED COMPONENTS
   random_numbers
   tf
   apriltags_ros
-)
+  swarmie_msgs
+  )
 
 catkin_package(
   CATKIN_DEPENDS geometry_msgs swarmie_msgs roscpp sensor_msgs std_msgs random_numbers tf apriltags_ros

--- a/src/rqt_rover_gui/CMakeLists.txt
+++ b/src/rqt_rover_gui/CMakeLists.txt
@@ -32,6 +32,7 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   ublox_msgs
   ublox_serialization
+  swarmie_msgs
 )
 
 find_package( Qt5 REQUIRED COMPONENTS Widgets Xml )


### PR DESCRIPTION
Added explicit dependencies on swarmie_msgs otherwise the headers may not be generated in time for the GUI and behaviours packages to find them.