### PR TITLE
Reset Obstacle Call Count (and minor deploy script fix)

### DIFF
--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -25,7 +25,7 @@ Check()
 {
 	cd ~
 
-	if [ [-z "$(ls -A $dirPath/src/ublox/)"] || [-z "$(ls -A $dirPath/src/apriltags_ros/)"] ]; then
+	if [ -z "$(ls -A $dirPath/src/ublox/)" ] || [ -z "$(ls -A $dirPath/src/apriltags_ros/)" ]; then
 		echo "The ublox and/or april tags submodule is missing."
 		cd $dirPath; #Entering directory/local git repo (needed to run git commands)
 		echo "Initiliazing and updating ublox and april tag submodules...";

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -707,6 +707,12 @@ void RoverGUIPlugin::currentRoverChangedEventHandler(QListWidgetItem *current, Q
 
 void RoverGUIPlugin::pollRoversTimerEventHandler()
 {
+    //If there are no rovers connected to the GUI, reset the obstacle call count to 0
+    if(ui.rover_list->count() == 0)
+    {
+        obstacle_call_count = 0;
+    }
+
     // Returns rovers that have created a status topic
     set<string>new_rover_names = findConnectedRovers();
 


### PR DESCRIPTION
The obstacle call count will reset only if there are no rovers connected to the GUI. Else, it will continue to count obstacles globally. I also made a quick fix my previous push of the deploy script. It was giving errors because I didn't format the if condition (for checking the ublox or april tag modules). However, there are no changes in script functionality. This is from issue #93.