### PR TITLE
Fixed Multiple Bugs for Startup Script

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,6 +322,11 @@ You are now set for rapid deployment and development!
 	+ Typing '-NB' will allow users to get a new branch at anytime
 	+ Typing '-RP' will allow users to re-pull from your current selected github branch
 
+If you want to use the script, and don't want to use the interface, you are able to do so.  Running any option (-R, -L, -G) followed by a -S will trigger a silent mode for the command, running your commands and returning to the terminal immediately afterwards.
+
+EX:  ```./deploy.sh -R -S robot1``` will attempt to connect and run robot1 from the script and return you to the terminal window
+
+
 Feature:
 
 Typing "REBOOT {hostname}" in any option will allow you to reboot the selected rover.

--- a/README.md
+++ b/README.md
@@ -322,10 +322,9 @@ You are now set for rapid deployment and development!
 	+ Typing '-NB' will allow users to get a new branch at anytime
 	+ Typing '-RP' will allow users to re-pull from your current selected github branch
 
-If you want to use the script, and don't want to use the interface, you are able to do so.  Running any option (-R, -L, -G) followed by a -S will trigger a silent mode for the command, running your commands and returning to the terminal immediately afterwards.
+If you want to use the script, and don't want to use the interface, you are able to do so.  Running any option (-R, -L, -G) followed by a -S will trigger a silent mode for the command, running your commands and returning to the terminal that the script was called from immediately after all operations are performed.
 
-EX:  ```./deploy.sh -R -S robot1``` will attempt to connect and run robot1 from the script and return you to the terminal window
-
+EX:  ```./deploy.sh -R -S robot1``` will attempt to connect and run robot1 and then return to the current terminal without opening the interface.
 
 Feature:
 

--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -25,7 +25,7 @@ Check()
 {
 	cd ~
 
-	if [ [-z "$(ls -A $dirPath/src/ublox/)"] || [-z "$(ls -A $dirPath/src/apriltags_ros/)"] ]; then
+        if [ -z "$(ls -A $dirPath/src/ublox/)" ] || [ -z "$(ls -A $dirPath/src/apriltags_ros/)" ]; then
 		echo "The ublox and/or april tags submodule is missing."
 		cd $dirPath; #Entering directory/local git repo (needed to run git commands)
 		echo "Initiliazing and updating ublox and april tag submodules...";
@@ -123,7 +123,6 @@ Run()
 
 DispOpt()
 {
-	echo "Your network info:  $hostName@$userIP"
 	echo ""
 	echo "Type 'exit' to quit"
 
@@ -145,9 +144,8 @@ DispOpt()
 	fi
 
 	echo "Type 'REBOOT {hostname}' to reboot a swarmie"
-
+        echo "Type desired rover name(s) to run"
 	echo "-------------------------------------------------------------"
-	echo ""
 }
 
 SuccessPing()
@@ -190,9 +188,6 @@ Reboot()
 userIP=$(ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }')
 hostName=$(hostname)
 
-echo "$dirPath"
-echo "$dirName"
-
 #No Connection
 #-------------------------------------------------------------
 if [ -z "$userIP" ]; then
@@ -213,35 +208,177 @@ if [ -z $OPTION ]; then
 	exit 1
 fi
 
-clear
-
 #check OPTION given
 #------------------------------------------------------------
 
 while(true); do
 
+echo $1 $2
+
+if [ $2 == "-N" ]; then
+
+    i=3
+
+    if [ $OPTION == "-G" ]; then
+
+        #Get Branch
+        read -e -p "Branch?:  " branch
+
+        Check
+
+        PullGit_Pack &
+        wait
+
+        while [ "${!i}" != "" ]; do
+            roverIP=${!i}
+            roverIP=${roverIP^^}
+
+            if [ $roverIP == "REBOOT" ]; then
+                needsReboot=true
+                i=$((i+1))
+                roverIP=${!i}
+                roverIP=${roverIP^^}
+            fi
+
+            #If rover is on the network
+            ping -q -w2 $roverIP > /dev/null
+            if [ $? -eq 0 ]; then
+
+                    if [ $needsReboot == true ]; then
+                            Reboot
+                            echo ""
+                            Run
+                            needsReboot=false
+                            sleep 10
+                    else
+                            #Transfer/Unpack/Run
+                            Transfer
+                            Unpack_Run
+                            sleep 10
+                    fi
+            #if not on the network
+            else
+                    FailPing
+                    needsReboot=false
+            fi
+
+            i=$((i+1))
+
+        done
+
+    elif [ $OPTION == "-L" ]; then
+
+        Pack &
+        wait
+
+        while [ "${!i}" != "" ]; do
+            roverIP=${!i}
+            roverIP=${roverIP^^}
+
+            if [ $roverIP == "REBOOT" ]; then
+                needsReboot=true
+                i=$((i+1))
+                roverIP=${!i}
+                roverIP=${roverIP^^}
+            fi
+
+            #if we didn't just select the reboot option
+            if [ $roverIP != "REBOOT" ]; then
+
+                #If rover is on the network
+                ping -q -w2 $roverIP > /dev/null
+
+                if [ $? -eq 0 ]; then
+
+                    if [ $needsReboot == true ]; then
+                        Reboot
+                        echo ""
+                        Run
+                        needsReboot=false
+                        sleep 10
+                    else
+                        #Transfer/Unpack/Run
+                         Transfer
+                        Unpack_Run
+                        sleep 10
+                    fi
+
+                #if not on the network
+                else
+                    FailPing
+                    needsReboot=false
+                fi
+            fi
+
+            i=$((i+1))
+
+        done
+
+    elif [ $OPTION == "-R" ]; then
+
+        while [ "${!i}" != "" ]; do
+
+            roverIP=${!i}
+            roverIP=${roverIP^^}
+
+            if [ $roverIP == "REBOOT" ]; then
+                needsReboot=true
+                i=$((i+1))
+                roverIP=${!i}
+                roverIP=${roverIP^^}
+            fi
+
+            ping -q -w2 $roverIP > /dev/null
+
+            #If rover is on the network
+            if [ $? -eq 0 ]; then
+
+                #reboot
+                if [ $needsReboot == true ]; then
+                    Reboot
+                    echo ""
+                    Run
+                    sleep 10
+                    needsReboot=false
+                else
+                    Run
+                    sleep 10
+                fi
+
+            #if not on the network
+            else
+                    FailPing
+                    needsReboot=false
+            fi
+
+            i=$((i+1))
+        done
+    else
+        echo "Not valid option"
+    fi
+
+exit 1
+
 #GitHub Selection
 #------------------------------------------------------------
-if [ $OPTION == "-G" ]; then
+elif [ $OPTION == "-G" ]; then
 
+    clear
 	#if not everything is filled out
 	if [ "$branch" == "" ]; then
 		echo ""
-    		read -p "Branch?:  " branch
+                read -e -p "Branch?:  " branch
 		echo ""
 	fi
 
 	#Tell User Option
 
+        echo "Your network info:  $hostName@$userIP"
 	echo "Retrieving and Transferring Code from GitHub:  "
-
 	echo "dir: $dirPath branch: $branch"
 	echo "-------------------------------------------------------------"
-	echo ""
 
 	Check
-
-	DispOpt
 
 	PullGit_Pack &
 	wait
@@ -251,7 +388,9 @@ if [ $OPTION == "-G" ]; then
 	i=0
 	changeOption=false
 
-		read -p "Rover Name/IP To Start:  " -a arr 
+                DispOpt
+
+                read -p "Option/Rover Name(s):  " -a arr
 
 		size=${#arr[@]}
 
@@ -335,21 +474,19 @@ if [ $OPTION == "-G" ]; then
 
 		i=0
 	done
-fi
 
 #Transfer Local Copy
 #-------------------------------------------------------------
-if [ $OPTION == "-L" ]; then
+elif [ $OPTION == "-L" ]; then
+
+    clear
 
 	Check
 
-	DispOpt
-
+        echo "Your network info:  $hostName@$userIP"
 	echo "Copying and transferring current folder to swarmie(s)"
-
 	echo "dir: $dirPath"
 	echo "-------------------------------------------------------------"
-	echo ""
 
 	Pack &
 	wait
@@ -359,7 +496,9 @@ if [ $OPTION == "-L" ]; then
 	i=0
 	changeOption=false
 
-		read -p "Rover Name/IP To Start:  " -a arr 
+                DispOpt
+
+                read -p "Option/Rover Name(s):  " -a arr
 
 		size=${#arr[@]}
 
@@ -385,8 +524,7 @@ if [ $OPTION == "-L" ]; then
 				break
 			elif [ $roverIP = "-RC" ]; then
 				clear
-				changeOption=true
-				echo ""
+                                changeOption=true
 				echo "-------------------------------------------------------------"
 				echo ""
 				echo "Recompiling Source Code!"
@@ -442,27 +580,27 @@ if [ $OPTION == "-L" ]; then
 
 		i=0
 	done
-fi
 
 #Just Run
 #-------------------------------------------------------------
-if [ $OPTION == "-R" ]; then
+elif [ $OPTION == "-R" ]; then
 
-	DispOpt
+    clear
 
+        echo "Your network info:  $hostName@$userIP"
 	echo "Running current swarmie(s) code"
 	echo "-------------------------------------------------------------"
-	echo ""
 
 	while(true); do
 
 	i=0
 	changeOption=false
 
-		read -p "Rover Name/IP To Start:  " -a arr 
+                DispOpt
 
-		size=${#arr[@]}
-		echo $size
+                read -p "Option/Rover Name(s):  " -a arr
+
+                size=${#arr[@]}
 
 		while [ $i -lt $size ]; do
 
@@ -473,7 +611,7 @@ if [ $OPTION == "-R" ]; then
 			i=$((i+1))
 		
 			#check input
-			if [ "$roverIP" =  "exit" ]; then
+                        if [ "$roverIP" =  "EXIT" ]; then
 				exit 1
 			elif [ "$roverIP" == "-G" ]; then
 				OPTION="-G"

--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -140,7 +140,7 @@ DispOpt()
 	if [ "$OPTION" != "-L" ]; then
 		echo "Type '-L' to transfer local code and run on swarmie(s)"
 	elif [ $OPTION == "-L" ]; then
-		echo "Type '-RC' to recompile Source Code"
+                echo "Type '-RC' to recompile Source Code"
 	fi
 
 	echo "Type 'REBOOT {hostname}' to reboot a swarmie"
@@ -204,6 +204,7 @@ if [ -z $OPTION ]; then
 	echo "'-G'[ithub] pulls and transfers workspace to swarmie(s)"
 	echo "'-L'[ocal Files] duplicates current workspace and transfers to swarmie(s)"
 	echo "'-R'[un] to run current code on all swarmie(s)"
+        echo "'-S'[ilent] after option to run and return to terminal without using interface"
 	echo "-------------------------------------------------------------"
 	exit 1
 fi
@@ -213,9 +214,7 @@ fi
 
 while(true); do
 
-echo $1 $2
-
-if [ $2 == "-N" ]; then
+if [ $2 == "-S" ]; then
 
     i=3
 
@@ -298,7 +297,7 @@ if [ $2 == "-N" ]; then
                         sleep 10
                     else
                         #Transfer/Unpack/Run
-                         Transfer
+                        Transfer
                         Unpack_Run
                         sleep 10
                     fi


### PR DESCRIPTION
Removed lingering code in -R section.  
Fixed error in check command from previous commit. 
Fixed issue in run where wouldn't exit when typing exit. 
Cleaned up user options prompt when running rovers in all options (fix for #101).  
Finished ability to run script from command line without the use of the interface. (fix #102)
- Typing -N will now not run the GUI and run everything and return back to the command terminal
    + ex:  ./deploy.sh -R -N r05

Need to still update the README and some internal script documentation.  Please check to see if this is working as I correct this.

Thanks!