### PR TITLE
Diagnostics error displaying "stoi"

### DIFF
--- a/src/diagnostics/src/WirelessDiags.cpp
+++ b/src/diagnostics/src/WirelessDiags.cpp
@@ -133,12 +133,15 @@ float WirelessDiags::calcBitRate() {
   prev_total_bytes = total_bytes;
    
   // Convert string to int
+  string::size_type sz;   // alias of size_t
   long int rx_bytes = 0;
   long int tx_bytes = 0;
-  if (!receive_stat.empty() && !transmit_stat.empty())
+  if (!receive_stat.empty())
   {
-    string::size_type sz;   // alias of size_t
     rx_bytes = stoi(receive_stat,&sz);
+  }
+  if (!transmit_stat.empty())
+  {
     tx_bytes = stoi(transmit_stat,&sz);
   }
 
@@ -264,7 +267,7 @@ WirelessInfo WirelessDiags::getInfo(){
   // We are done so clean up
   close(sockfd);
 
-  calcBitRate();  
+  sigInfo.bandwidthUsed = calcBitRate();  
 
   return sigInfo;
 }

--- a/src/diagnostics/src/WirelessDiags.cpp
+++ b/src/diagnostics/src/WirelessDiags.cpp
@@ -133,9 +133,14 @@ float WirelessDiags::calcBitRate() {
   prev_total_bytes = total_bytes;
    
   // Convert string to int
-  string::size_type sz;   // alias of size_t
-  long int rx_bytes = stoi(receive_stat,&sz);
-  long int tx_bytes = stoi(transmit_stat,&sz);
+  long int rx_bytes = 0;
+  long int tx_bytes = 0;
+  if (!receive_stat.empty() && !transmit_stat.empty())
+  {
+    string::size_type sz;   // alias of size_t
+    rx_bytes = stoi(receive_stat,&sz);
+    tx_bytes = stoi(transmit_stat,&sz);
+  }
 
   // Get the total bytes transmitted and recevied. This is the total bandwidth used.
   total_bytes = rx_bytes + tx_bytes;
@@ -259,7 +264,7 @@ WirelessInfo WirelessDiags::getInfo(){
   // We are done so clean up
   close(sockfd);
 
-  sigInfo.bandwidthUsed = calcBitRate();  
+  calcBitRate();  
 
   return sigInfo;
 }


### PR DESCRIPTION
…nostics and call WirelessDiag::calcBitRate() which return corrupt values when variables receive_stat and/or transmit_stat are empty, executes stoi on empty strings. Can replicate bug by adding receive_stat.clear(); and/or transmit_stat.clear(); before calling stoi.