### PR TITLE
Reset Obstacle Call Count

### DIFF
--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -1,6 +1,6 @@
 // Author: Matthew Fricke
 // E-mail: matthew@fricke.co.uk
-// Date: 9-16-205
+// Date: 9-16-2015
 // Purpose: implementation of a simple graphical front end for the UNM-NASA Swarmathon rovers.
 // License: GPL3
 
@@ -707,6 +707,12 @@ void RoverGUIPlugin::currentRoverChangedEventHandler(QListWidgetItem *current, Q
 
 void RoverGUIPlugin::pollRoversTimerEventHandler()
 {
+    //If there are no rovers connected to the GUI, reset the obstacle call count to 0
+    if(ui.rover_list->count() == 0)
+    {
+        obstacle_call_count = 0;
+    }
+
     // Returns rovers that have created a status topic
     set<string>new_rover_names = findConnectedRovers();
 


### PR DESCRIPTION
The obstacle call count will reset only if there are no rovers connected to the GUI. Else, it will continue to count obstacles globally. This fixes issue #93. Also, fixed a typo in the date on the top.

(I created a new pull request because my git config file was registered with Matthew's information.)