### PR TITLE
Hotfix: Obstacle node was still being checked for in diagnostics

### DIFF
--- a/src/diagnostics/src/Diagnostics.cpp
+++ b/src/diagnostics/src/Diagnostics.cpp
@@ -28,7 +28,6 @@ Diagnostics::Diagnostics(std::string name) {
   sonarRightSubscribe = nodeHandle.subscribe(publishedName + "/sonarRight", 10, &Diagnostics::sonarRightTimestampUpdate, this);
   abdridgeNodeSubscribe = nodeHandle.subscribe(publishedName + "/abridge/heartbeat", 1, &Diagnostics::abridgeNode,this);
   sbdridgeNodeSubscribe = nodeHandle.subscribe(publishedName + "/sbridge/heartbeat", 1, &Diagnostics::sbridgeNode,this);
-  obstacleNodeSubscribe = nodeHandle.subscribe(publishedName + "/obstacle/heartbeat", 1, &Diagnostics::obstacleNode,this);
   behaviourNodeSubscribe = nodeHandle.subscribe(publishedName + "/behaviour/heartbeat", 1, &Diagnostics::behaviourNode,this);
   ubloxNodeSubscribe = nodeHandle.subscribe(publishedName + "/fix" , 1, &Diagnostics::ubloxNode,this);
 
@@ -155,10 +154,6 @@ void Diagnostics::sbridgeNode(std_msgs::String msg) {
     sbridgeNodeTimestamp = ros::Time::now();
 }
 
-void Diagnostics::obstacleNode(std_msgs::String msg) {
-    obstacleNodeTimestamp = ros::Time::now();
-}
-
 void Diagnostics::behaviourNode(std_msgs::String msg) {
     behaviourNodeTimestamp = ros::Time::now();
 }
@@ -210,7 +205,6 @@ void Diagnostics::nodeCheckTimerEventHandler(const ros::TimerEvent& event) {
        checkSbridge();
     }
 
-    checkObstacle();
     checkBehaviour();
 
 }
@@ -386,20 +380,6 @@ void Diagnostics::checkSbridge() {
     else if (sbridgeRunning) {
         sbridgeRunning = false;
         publishErrorLogMessage("the sbridge node is not running");
-    }
-}
-
-void Diagnostics::checkObstacle() {
-
-    if (ros::Time::now() - obstacleNodeTimestamp <= ros::Duration(node_heartbeat_timeout)) {
-        if (!obstacleRunning) {
-            obstacleRunning = true;
-            publishInfoLogMessage("the obstacle node is now running");
-        }
-    }
-    else if (obstacleRunning) {
-        obstacleRunning = false;
-        publishErrorLogMessage("the obstacle node is not running");
     }
 }
 

--- a/src/diagnostics/src/Diagnostics.h
+++ b/src/diagnostics/src/Diagnostics.h
@@ -43,7 +43,6 @@ public:
   void sonarRightTimestampUpdate(const sensor_msgs::Range::ConstPtr& message);
   void abridgeNode(std_msgs::String msg);
   void sbridgeNode(std_msgs::String msg);
-  void obstacleNode(std_msgs::String msg);
   void behaviourNode(std_msgs::String msg);
   void ubloxNode(const sensor_msgs::NavSatFixConstPtr& message);
   
@@ -77,7 +76,6 @@ private:
 
   void checkAbridge();
   void checkSbridge();
-  void checkObstacle();
   void checkBehaviour();
   void checkUblox();
     
@@ -108,7 +106,6 @@ private:
   ros::Subscriber sonarRightSubscribe;
   ros::Subscriber abdridgeNodeSubscribe;
   ros::Subscriber sbdridgeNodeSubscribe;
-  ros::Subscriber obstacleNodeSubscribe;
   ros::Subscriber behaviourNodeSubscribe;
   ros::Subscriber ubloxNodeSubscribe;
   
@@ -135,7 +132,6 @@ private:
   bool sonarRightConnected = false;
   bool abridgeRunning = true;
   bool sbridgeRunning = true;
-  bool obstacleRunning = true;
   bool behaviourRunning = true;
   bool ubloxRunning = true;
 
@@ -149,7 +145,6 @@ private:
   ros::Time sonarRightTimestamp;
   ros::Time abridgeNodeTimestamp;
   ros::Time sbridgeNodeTimestamp;
-  ros::Time obstacleNodeTimestamp;
   ros::Time behaviourNodeTimestamp;
   ros::Time ubloxNodeTimestamp;
 


### PR DESCRIPTION
Removed references to the obstacle node in diagnostics. The code that was in obstacle is now in the behaviours package and the obstacle package has been removed. Diagnostics was still sending error messages to the UI about the absence of obstacle.