### PR TITLE
Bug motor overcurrent

### DIFF
--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -54,7 +54,7 @@ float heartbeat_publish_interval = 2;
 
 float prev_left = 0;
 float prev_right = 0;
-int max_motor_step = 25;
+int max_motor_step = 15;
 
 ros::Time prevDriveCommandUpdateTime;
 
@@ -148,17 +148,17 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   float left = (message->linear.x); //target linear velocity in meters per second
   float right = (message->angular.z); //angular error in radians
   
-  cout << "Left: " << left << " Right: " << right << endl;
+  //cout << "Left: " << left << " Right: " << right << endl;
 
-  if(abs(prev_left - left) > max_motor_step && left != 0 )
+  if(abs(prev_left - left) > max_motor_step)
   {
-    left = prev_left + max_motor_step * (left/abs(left));
+    left = prev_left + max_motor_step * ((left - prev_left)/abs(left-prev_left));
 cout << "left: " << left << endl;
   }
   
-  if(abs(prev_right - right) > max_motor_step && right != 0)
+  if(abs(prev_right - right) > max_motor_step)
   {
-    right = prev_right + max_motor_step * (right/abs(right));
+    right = prev_right + max_motor_step * ((right - prev_right)/abs(right-prev_right));
 cout << "right: " << right << endl;
   }
   

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -54,7 +54,7 @@ float heartbeat_publish_interval = 2;
 
 float prev_left = 0;
 float prev_right = 0;
-int max_motor_step = 15;
+int max_motor_step = 75;
 
 ros::Time prevDriveCommandUpdateTime;
 
@@ -148,18 +148,26 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   float left = (message->linear.x); //target linear velocity in meters per second
   float right = (message->angular.z); //angular error in radians
   
-  //cout << "Left: " << left << " Right: " << right << endl;
+  ///TODO: replace below with a variable motor step size based upon a delta time.
+  if (mode == 1)
+  {
+      max_motor_step = 15;
+  }
+  else
+  {
+      max_motor_step = 75;
+  }
 
+  //steps the motor power up or down by a max ammount per tick, this prevents commanding a speed change that is too large at any one time step
+  //this prevents or limits the potential for overcurrent situations.
   if(abs(prev_left - left) > max_motor_step)
   {
     left = prev_left + max_motor_step * ((left - prev_left)/abs(left-prev_left));
-cout << "left: " << left << endl;
   }
   
   if(abs(prev_right - right) > max_motor_step)
   {
     right = prev_right + max_motor_step * ((right - prev_right)/abs(right-prev_right));
-cout << "right: " << right << endl;
   }
   
   prev_left = left;

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -54,8 +54,7 @@ float heartbeat_publish_interval = 2;
 
 float prev_left = 0;
 float prev_right = 0;
-int max_motor_step = 1
-;
+int max_motor_step = 25;
 
 ros::Time prevDriveCommandUpdateTime;
 
@@ -149,15 +148,17 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   float left = (message->linear.x); //target linear velocity in meters per second
   float right = (message->angular.z); //angular error in radians
   
-  if(fabs(left)-fabs(prev_left) > max_motor_step && prev_left != 0)
+  cout << "Left: " << left << " Right: " << right << endl;
+
+  if(abs(prev_left - left) > max_motor_step && left != 0 )
   {
-    left = prev_left + max_motor_step * (left/fabs(left));
+    left = prev_left + max_motor_step * (left/abs(left));
 cout << "left: " << left << endl;
   }
   
-  if(fabs(prev_right) > max_motor_step && prev_right != 0)
+  if(abs(prev_right - right) > max_motor_step && right != 0)
   {
-    right = prev_right + max_motor_step * (right/fabs(right));
+    right = prev_right + max_motor_step * (right/abs(right));
 cout << "right: " << right << endl;
   }
   
@@ -172,19 +173,23 @@ cout << "right: " << right << endl;
   if (left > max_motor_cmd)
   {
     left = max_motor_cmd;
+    prev_left = max_motor_cmd;
   }
   else if (left < -max_motor_cmd)
   {
     left = - max_motor_cmd;
+    prev_left = - max_motor_cmd;
   }
 
   if (right > max_motor_cmd)
   {
     right = max_motor_cmd;
+    prev_right = max_motor_cmd;
   }
   else if (right < -max_motor_cmd)
   {
     right = -max_motor_cmd;
+    prev_right = -max_motor_cmd;
   }
 
   int leftInt = left;

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -54,7 +54,8 @@ float heartbeat_publish_interval = 2;
 
 float prev_left = 0;
 float prev_right = 0;
-int max_motor_step = 100;
+int max_motor_step = 1
+;
 
 ros::Time prevDriveCommandUpdateTime;
 
@@ -148,14 +149,16 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
   float left = (message->linear.x); //target linear velocity in meters per second
   float right = (message->angular.z); //angular error in radians
   
-  if(fabs(prev_left) > max_motor_step)
+  if(fabs(left)-fabs(prev_left) > max_motor_step && prev_left != 0)
   {
     left = prev_left + max_motor_step * (left/fabs(left));
+cout << "left: " << left << endl;
   }
   
-  if(fabs(prev_right) > max_motor_step)
+  if(fabs(prev_right) > max_motor_step && prev_right != 0)
   {
     right = prev_right + max_motor_step * (right/fabs(right));
+cout << "right: " << right << endl;
   }
   
   prev_left = left;
@@ -163,7 +166,7 @@ void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message) {
 
   // Cap motor commands at 120. Experimentally determined that high values (tested 180 and 255) can cause 
   // the hardware to fail when the robot moves itself too violently.
-  int max_motor_cmd = 120;
+  int max_motor_cmd = 255;
 
   // Check that the resulting motor commands do not exceed the specified safe maximum value
   if (left > max_motor_cmd)


### PR DESCRIPTION
This pull will add a motor step function in abridge. This causes the robot to change speed by a maximum value per frame. As speed changes are limited it is now difficult to ask for a speed change that would cause an over current event.

It may still be possible by taking a joystick and twirling it in a circle as fast as possible asking for rapid left right and forward reverse commands simultaneously. However this is a useless maneuver and thus is deliberately attempting to break the robot as this does not work in auto-mode.