### PR TITLE
Deploy script should copy symlinks as regular files

### DIFF
--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -50,7 +50,7 @@ PullGit_Pack()
 				{
 					cd -;
 					echo 'Packing up the repository... ';
-					tar czf $dirName.tgz $dirPath;
+					tar czhf $dirName.tgz $dirPath;
 					exit 1;
 				}
 				read stuff;
@@ -75,7 +75,7 @@ Pack()
 			{ 
 				cd ~;
 				echo 'Packing up the repository... ';
-				tar czf $dirName.tgz $dirName;
+				tar czhf $dirName.tgz $dirName;
 				exit 0;
 			}
 			read stuff


### PR DESCRIPTION
If symlinks are copied as links this will cause broken links on the
rover and may cause the deploy process to fail. Instead we use the -h
flag on tar to replace symlinks with the files they point to.