### PR TITLE
Hotfix reset manual waypoints

### DIFF
--- a/src/behaviours/src/LogicController.cpp
+++ b/src/behaviours/src/LogicController.cpp
@@ -374,6 +374,7 @@ void LogicController::SetModeAuto() {
   if(processState == PROCESS_STATE_MANUAL) {
     // only do something if we are in manual mode
     this->Reset();
+    manualWaypointController.Reset();
   }
 }
 void LogicController::SetModeManual()

--- a/src/behaviours/src/ManualWaypointController.cpp
+++ b/src/behaviours/src/ManualWaypointController.cpp
@@ -9,6 +9,8 @@ ManualWaypointController::~ManualWaypointController() {}
 
 void ManualWaypointController::Reset() {
   waypoints.clear();
+  num_waypoints = 0;
+  cleared_waypoints.clear();
 }
 
 bool ManualWaypointController::HasWork() {

--- a/src/rqt_rover_gui/src/MapData.cpp
+++ b/src/rqt_rover_gui/src/MapData.cpp
@@ -422,6 +422,7 @@ void MapData::setAutonomousMode(string rover_name)
 {
    update_mutex.lock();
    rover_mode[rover_name] = 1;
+   resetWaypointPathForSelectedRover(rover_name);
    update_mutex.unlock();
 }
 


### PR DESCRIPTION
When entering autonomous mode, remove all manual waypoints to stop the rover from driving off on its own when you go back to manual mode.