### PR TITLE
Make better use of GPS

### DIFF
--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -109,7 +109,7 @@ long int startTime = 0;
 float minutesTime = 0;
 float hoursTime = 0;
 
-float drift_tolerance = 5; // meters
+float drift_tolerance = 0.5; // meters
 
 Result result;
 
@@ -133,7 +133,7 @@ ros::Publisher waypointFeedbackPublisher;
 
 // Subscribers
 ros::Subscriber joySubscriber;
-ros::Subscriber modeSubscriber;
+ros::Subscriber modeSubscriber; 
 ros::Subscriber targetSubscriber;
 ros::Subscriber odometrySubscriber;
 ros::Subscriber mapSubscriber;
@@ -150,7 +150,7 @@ time_t timerStartTime;
 
 // An initial delay to allow the rover to gather enough position data to 
 // average its location.
-unsigned int startDelayInSeconds = 15;
+unsigned int startDelayInSeconds = 30;
 float timerTimeElapsed = 0;
 
 //Transforms


### PR DESCRIPTION
The odeometry estimate of the collection zone location is synced with the GPS estimate when they differ by more than 0.5 (previously 5m). This change increases the number of cubes collected by 3 rovers in 30 mins from 1 to 13.

The startup delay has been changed from 15 s to 30 s. This is to give the rovers more time to estimate their initial location using GPS.