### PR TITLE
Fix constant erroneous disconnect messages.

### DIFF
--- a/src/diagnostics/src/Diagnostics.cpp
+++ b/src/diagnostics/src/Diagnostics.cpp
@@ -18,7 +18,7 @@ Diagnostics::Diagnostics(std::string name) {
 
   this->publishedName = name;
   diagLogPublisher = nodeHandle.advertise<std_msgs::String>("/diagsLog", 1, true);
-  diagnosticDataPublisher  = nodeHandle.advertise<std_msgs::Float32MultiArray>("/"+publishedName+"/diagnostics", 10);
+  diagnosticDataPublisher  = nodeHandle.advertise<std_msgs::Float32MultiArray>("/"+publishedName+"/diagnostics", 1);
   fingerAngleSubscribe = nodeHandle.subscribe(publishedName + "/fingerAngle/prev_cmd", 10, &Diagnostics::fingerTimestampUpdate, this);
   wristAngleSubscribe = nodeHandle.subscribe(publishedName + "/fingerAngle/prev_cmd", 10, &Diagnostics::wristTimestampUpdate, this);
   imuSubscribe = nodeHandle.subscribe(publishedName + "/imu", 10, &Diagnostics::imuTimestampUpdate, this);

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -525,7 +525,7 @@ set<string> RoverGUIPlugin::findConnectedRovers()
 void RoverGUIPlugin::statusEventHandler(const ros::MessageEvent<std_msgs::String const> &event)
 {
     const ros::M_string& header = event.getConnectionHeader();
-    ros::Time receipt_time = event.getReceiptTime();
+    ros::Time receipt_time = ros::Time::now();
 
     // Extract rover name from the message source
 
@@ -877,7 +877,7 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
         ekf_subscribers[*i] = nh.subscribe("/"+*i+"/odom/ekf", 10, &RoverGUIPlugin::EKFEventHandler, this);
         gps_subscribers[*i] = nh.subscribe("/"+*i+"/odom/navsat", 10, &RoverGUIPlugin::GPSEventHandler, this);
         gps_nav_solution_subscribers[*i] = nh.subscribe("/"+*i+"/navsol", 10, &RoverGUIPlugin::GPSNavSolutionEventHandler, this);
-        rover_diagnostic_subscribers[*i] = nh.subscribe("/"+*i+"/diagnostics", 10, &RoverGUIPlugin::diagnosticEventHandler, this);
+        rover_diagnostic_subscribers[*i] = nh.subscribe("/"+*i+"/diagnostics", 1, &RoverGUIPlugin::diagnosticEventHandler, this);
 
         RoverStatus rover_status;
         // Build new ui rover list string


### PR DESCRIPTION
This patch fixes the constant erroneous disconnect messages in the GUI. 

It does two things: 

1. Reduce the queue size for diagnostic messages to one. There's no need to queue diagnostic messages because old ones are not useful. 
2. Sets the timestamp of the received message in the GUI to ros::Time::now(). 

The underlying problem seems to be that event.getReceiptTime() returns zero always. This seems like a bug in ROS but it might just be poor documentation. I suspect that in order for this to work the message must be defined to have a std_msgs/Header. At the time scale that matters for diagnostic messages this is good enough. 
