### PR TITLE
Changed direct pathing to relative pathing

### DIFF
--- a/misc/deploy.sh
+++ b/misc/deploy.sh
@@ -114,7 +114,7 @@ Run()
 	#ssh and run script from rover --WORKS
 	gnome-terminal --tab -x bash -c "echo -n -e '\033]0;$roverIP\007';
 		ssh -t swarmie@$roverIP 'echo 'Running $roverIP';
-		cd SwarmBaseCode-ROS/misc;
+    cd $dirName/misc;
 		./rover_onboard_node_launch.sh $hostName;
 		exit 1;
 		exit 1;

--- a/misc/rover_onboard_node_launch.sh
+++ b/misc/rover_onboard_node_launch.sh
@@ -57,8 +57,8 @@ nohup > logs/$HOSTNAME"_transform_log.txt" rosrun tf static_transform_publisher 
 echo "rosrun video_stream_opencv"
 
 #nohup rosrun video_stream_opencv video_stream __name:=$HOSTNAME\_CAMERA _video_stream_provider:=/dev/video0 /camera:=/$HOSTNAME/camera/image _camera_info_url:=file://${HOME}/SwarmBaseCode-ROS/camera_info head_camera.yaml _width:=320 _height:=240 &
-nohup > logs/$HOSTNAME"_USBCAM_log.txt" rosrun usb_cam usb_cam_node __name:=$HOSTNAME\_CAMERA /$HOSTNAME\_CAMERA/image_raw:=/$HOSTNAME/camera/image _camera_info_url:=file://$HOME/SwarmBaseCode-ROS/camera_info/head_camera.yaml _image_width:=320 _image_height:=240 &
-
+nohup > logs/$HOSTNAME"_USBCAM_log.txt" rosrun usb_cam usb_cam_node __name:=$HOSTNAME\_CAMERA /$HOSTNAME\_CAMERA/image_raw:=/$HOSTNAME/camera/image _camera_info_url:=file://$(realpath ..)/camera_info/head_camera.yaml _image_width:=320 _image_height:=240 &
+echo $(realpath ..)/camera_info/head_camera.yaml
 # deprecated; we are replacing the usb cam with opencv cam
 # mage_raw:=/$HOSTNAME/camera/image _camera_info_url:=file://${HOME}/rover_workspace/camera_info/head_camera.yaml _image_width:=320 _image_height:=240 &
 


### PR DESCRIPTION
deploy and rover_onboard_node_launch both used a fixed path that would result in issues if SwarmBaseCode-ROS wasn't existing on the rover.  Would cause the rover to refuse to acknowledge tags due to distance always being 0 (rover_onboard_node_launch) and the eploy script only searching for SwarmBaseCode-ROS with the run option.

Jaretts account changed my checkin for me.  :(

Addresses issue #156 