### PR TITLE
Hotfix for invalid start when cube visible

### DIFF
--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -431,6 +431,9 @@ void sendDriveCommand(double left, double right)
  *************************/
 
 void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& message) {
+
+  if(currentMode == 0 || currentMode == 1) { return; }
+
   
   if (message->detections.size() > 0) {
     vector<Tag> tags;

--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -432,9 +432,13 @@ void sendDriveCommand(double left, double right)
 
 void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& message) {
 
-  if(currentMode == 0 || currentMode == 1) { return; }
+  // Don't pass April tag data to the logic controller if the robot is not in autonomous mode.
+  // This is to make sure autonomous behaviours are not triggered while the rover is in manual mode. 
+  if(currentMode == 0 || currentMode == 1) 
+  { 
+    return; 
+  }
 
-  
   if (message->detections.size() > 0) {
     vector<Tag> tags;
 


### PR DESCRIPTION
This fixed the robot getting into an invalid state of operation causing it to no longer respond to cubes if cubes are visible upon first startup

This fixes issue #103 