### PR TITLE
Update AprilTags_ROS submodule to BCLabs-UNM's version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,8 @@
 	url = https://github.com/KumarRobotics/ublox.git
 [submodule "src/apriltags_ros"]
 	path = src/apriltags_ros
-	url = https://github.com/RIVeR-Lab/apriltags_ros.git
+	url = https://github.com/BCLab-UNM/apriltags_ros.git
+	branch = kinetic-master
 [submodule "src/usb_cam"]
 	path = src/usb_cam
 	url = https://github.com/bosch-ros-pkg/usb_cam.git


### PR DESCRIPTION
River Labs AprilTags_ROS is not compatible with OpenCV 3.3.1. This seems to result in a crash in the camera stream. We forked the AprilTags library and fixed the problem. Now we make SwarmBaseCode use the fixed repository.

The problem shows up in sim as a frozen camera. 