### PR TITLE
fixed GUI crash bug when GUI is closed with popout map active

### DIFF
--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -319,7 +319,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
       point.setY(map_origin_y+coordinate.second*map_height);
       scaled_target_locations.push_back(point);
     }
-    
+
     std::vector<QPoint> scaled_collection_points;
     for(std::vector< pair<float,float> >::iterator it = map_data->getCollectionPoints(rover_to_display)->begin(); it < map_data->getCollectionPoints(rover_to_display)->end(); ++it)
     {
@@ -334,7 +334,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     for(std::vector< pair<float,float> >::iterator it = map_data->getGPSPath(rover_to_display)->begin(); it < map_data->getGPSPath(rover_to_display)->end(); ++it)
     {
       pair<float,float> coordinate  = *it;
-      
+
       float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
       float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
       scaled_gps_rover_points.push_back( QPoint(x,y) );
@@ -347,10 +347,10 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     // Calculate the axis positions
     map_origin_x = fm.width(QString::number(-max_seen_height, 'f', 1)+"m");
     map_origin_y = 2*fm.height();
-    
+
     map_width = this->width()-1;// Minus 1 or will go off the edge
     map_height = this->height()-1;//
-    
+
     map_center_x = map_origin_x+((map_width-map_origin_x)/2);
     map_center_y = map_origin_y+((map_height-map_origin_y)/2);
 
@@ -401,7 +401,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
       QPoint point;
       float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
       float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-      
+
       // Move to the starting point of the path without drawing a line
       if (it == map_data->getEKFPath(rover_to_display)->begin()) scaled_ekf_rover_path.moveTo(x, y);
       scaled_ekf_rover_path.lineTo(x, y);
@@ -409,18 +409,18 @@ void MapFrame::paintEvent(QPaintEvent* event) {
 
     QPainterPath scaled_encoder_rover_path;
     for(std::vector< pair<float,float> >::iterator it = map_data->getEncoderPath(rover_to_display)->begin(); it < map_data->getEncoderPath(rover_to_display)->end(); ++it)
-    { 
+    {
       pair<float,float> coordinate  = *it;
       QPoint point;
       float x = map_origin_x+((coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
       float y = map_origin_y+((coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-      
+
       // Move to the starting point of the path without drawing a line
       if (it == map_data->getEncoderPath(rover_to_display)->begin()) scaled_encoder_rover_path.moveTo(x, y);
 
       scaled_encoder_rover_path.lineTo(x, y);
     }
-    
+
     QColor rover_color = QColor(255, 255, 255); // white
 
     // if we have properly set a color for simulated rovers initialise the color here
@@ -428,7 +428,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     if(unique_simulated_rover_colors.find(rover_to_display) != unique_simulated_rover_colors.end())
     {
       rover_color = unique_simulated_rover_colors[rover_to_display];
-      
+
       if(popout_mapframe)
       {
         popout_mapframe->setUniqueRoverColor(rover_to_display, unique_simulated_rover_colors[rover_to_display]);
@@ -477,19 +477,19 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     painter.setPen(green);
     point_array = &scaled_target_locations[0];
     painter.drawPoints(point_array, scaled_target_locations.size());
-      
+
     // Draw the waypoints for the current rover
     painter.setPen(Qt::cyan);
-    
+
     QPainterPath scaled_waypoint_rover_path;
     for(map< int, std::tuple<float,float,bool> >::iterator it = map_data->getWaypointPath(rover_to_display)->begin(); it != map_data->getWaypointPath(rover_to_display)->end(); ++it)
-    {	
+    {
       tuple<float,float,bool> coordinate  = it->second; // Get the value from the map
-      
+
       float x = map_origin_x+((get<0>(coordinate)-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
       float y = map_origin_y+((get<1>(coordinate)-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
-      
-      
+
+
       QPoint point(x,y);
       int default_pen_width = painter.pen().width();
       QPen previous_pen = painter.pen();
@@ -505,12 +505,12 @@ void MapFrame::paintEvent(QPaintEvent* event) {
       pen.setWidth(5);
       painter.setPen(pen);
       painter.drawPoint(point);
-      
+
       // Draw lines connecting waypoints
       painter.setPen(previous_pen);
-      
+
       painter.setPen(Qt::blue);
-      
+
       // Move to the starting point of the path without drawing a line
       if (it == map_data->getWaypointPath(rover_to_display)->begin())
       {
@@ -523,21 +523,21 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     }
 
     painter.drawPath(scaled_waypoint_rover_path);
-    
+
 
     if(display_unique_rover_colors) painter.setPen(rover_color);
     else painter.setPen(Qt::yellow);
-    
+
     pair<float,float> current_coordinate;
     if(! map_data->getEKFPath(rover_to_display)->empty() )
     {
        current_coordinate = map_data->getEKFPath(rover_to_display)->back();
     }
-    
+
     float x = map_origin_x+((current_coordinate.first-min_seen_x)/max_seen_width)*(map_width-map_origin_x);
     float y = map_origin_y+((current_coordinate.second-min_seen_y)/max_seen_height)*(map_height-map_origin_y);
     float radius = 2.5;
-    
+
     painter.drawEllipse(QPointF(x,y), radius, radius);
     painter.drawText(QPoint(x,y), QString::fromStdString(rover_to_display));
 
@@ -547,7 +547,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
   } // End rover display list set iteration
 
   map_data->unlock();
-  
+
   // Diagnostic output
   /*
   font.setPointSizeF( 12 );
@@ -652,7 +652,7 @@ void MapFrame::mousePressEvent(QMouseEvent *event)
   }
 
   float waypoint_click_tolerance = 0.25*(scale/10);
-  
+
   if ( event->buttons() == Qt::RightButton )
   {
     // Solve for map coordinates in terms of frame coordinates
@@ -670,7 +670,7 @@ void MapFrame::mousePressEvent(QMouseEvent *event)
     }
 
     emit sendInfoLogMessage("MOX: " + QString::number(map_origin_x) + " map_width: " + QString::number(map_width) + " max_seen_width: " +  QString::number(min_seen_x));
-    
+
     // If click is within eplison of an existing waypoint remove the waypoint
     bool waypoint_removed = false;
     for(map< int, std::tuple<float,float,bool> >::iterator it = map_data->getWaypointPath(rover_currently_selected)->begin(); it != map_data->getWaypointPath(rover_currently_selected)->end(); ++it)
@@ -687,15 +687,15 @@ emit sendInfoLogMessage(" x1: " + QString::number(x1)
                               + " y1: " + QString::number(y1)
                               + " y2: " + QString::number(y2)
                         + " dist: " + QString::number(sqrt( pow( x1 - x2, 2 ) + pow( y1 - y2, 2 ) ) ) + " scale: " + QString::number(scale) );
-      
-      if ( sqrt( pow( x1 - x2, 2 ) + pow( y1 - y2, 2 ) ) < waypoint_click_tolerance ) 
+
+      if ( sqrt( pow( x1 - x2, 2 ) + pow( y1 - y2, 2 ) ) < waypoint_click_tolerance )
       {
         int waypoint_id = it->first;
         removeWaypoint( rover_currently_selected, waypoint_id );
         waypoint_removed = true;
       }
     }
-    
+
     if ( !waypoint_removed )
     {
       emit sendInfoLogMessage(" Adding waypoint at x: " + QString::number(mouse_map_x) + " y: " + QString::number(mouse_map_y));
@@ -706,7 +706,7 @@ emit sendInfoLogMessage(" x1: " + QString::number(x1)
   {
     previous_clicked_position = event->pos();
   }
-  
+
     // emit sendInfoLogMessage("MapFrame: mouse press. x: " + QString::number(mouse_event->pos().x()) + ", y: " + QString::number(mouse_event->pos().y()));
 
 }
@@ -730,17 +730,17 @@ void MapFrame::mouseMoveEvent(QMouseEvent *event)
         QMouseEvent* mouse_event = static_cast<QMouseEvent*>(event);
         float max_width = this->width();
         float max_height = this->height();
-        
+
         // start with the previous translate
         translate_x = previous_translate_x;
         translate_y = previous_translate_y;
-        
+
         // add the scaled translation based on the previous mouse click
         // and the current mouse position while dragging; multiply the translation
         // by the given translate speed to keep the map lined up with mouse movement
         translate_x += translate_speed * (previous_clicked_position.x() - mouse_event->pos().x()) / max_width;
         translate_y += translate_speed * (previous_clicked_position.y() - mouse_event->pos().y()) / max_height;
-        
+
         // debug info log messages
         // emit sendInfoLogMessage("MapFrame: mouse move: translate_x: " + QString::number(translate_x) + " translate_y: " + QString::number(translate_y) + "\n");
         // emit sendInfoLogMessage("MapFrame: mouse move: frame_width: " + QString::number(this->width()) + " frame_height: " + QString::number(this->height()));
@@ -759,7 +759,7 @@ void MapFrame::wheelEvent(QWheelEvent *event)
   // cause undesired results.
   if (auto_transform == true) return;
 
-  // 100% map zoom is set when scale = 10; 10% adjustments to 
+  // 100% map zoom is set when scale = 10; 10% adjustments to
   // the zoom occur with each mouse wheel adjustment
   if (event->delta() < 0) {
     scale++;
@@ -845,6 +845,8 @@ void MapFrame::setAutoTransform()
 
 void MapFrame::clear()
 {
+  if (popout_window) popout_window->close();
+
   map_data->lock();
   display_list.clear();
   map_data->unlock();


### PR DESCRIPTION
The Problem:
    The GUI would hange and crash un-elegantly when exited with
    an active popout window.

The Solution:
    In the MapFrame clear() function a call to popout_window->close()
    has been added.

    When you exit the GUI, the shutdownPlugin() function is called
    in the rover_gui_plugin class. This function calls the MapFrame's
    clear() function to clear the map and stop drawing before the
    map frame is destroyed.

    Because we know that this function is called when the GUI is
    exiting, we have added an explicit function call to close the
    popout_window if and only if it is currently active.

    In this way, the window is closed before the rovers are shut
    down and the entire crashing/hanging problem is completely
    avoided where the popout window is trying to access null data.