### PR TITLE
Assign the name gzclient to the gazebo_ros client node

### DIFF
--- a/src/rqt_rover_gui/src/GazeboSimManager.cpp
+++ b/src/rqt_rover_gui/src/GazeboSimManager.cpp
@@ -64,7 +64,7 @@ QProcess* GazeboSimManager::startGazeboClient()
 
     gazebo_client_process = new QProcess();
 
-    QString command = QString("rosrun gazebo_ros gzclient");
+    QString command = QString("rosrun gazebo_ros gzclient __name:=gzclient");
 
     gazebo_client_process->start(command);
 


### PR DESCRIPTION
Fixes #187 

Tested multiple start/stop viz scenarios. Ensured that simulated robots respond to auto/manual mode and that  they still collect cubes with/without viz.