### PR TITLE
Virtual fence ui

### DIFF
--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -22,6 +22,7 @@
 #include <apriltags_ros/AprilTagDetectionArray.h>
 #include <std_msgs/Float32MultiArray.h>
 #include "swarmie_msgs/Waypoint.h"
+#include "swarmie_msgs/VirtualFence.h"
 
 // Include Controllers
 #include "LogicController.h"
@@ -169,7 +170,7 @@ void modeHandler(const std_msgs::UInt8::ConstPtr& message);
 void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& tagInfo);
 void odometryHandler(const nav_msgs::Odometry::ConstPtr& message);
 void mapHandler(const nav_msgs::Odometry::ConstPtr& message);
-void virtualFenceHandler(const std_msgs::Float32MultiArray& message);
+void virtualFenceHandler(const swarmie_msgs::VirtualFence& message);
 void manualWaypointHandler(const swarmie_msgs::Waypoint& message);
 void behaviourStateMachine(const ros::TimerEvent&);
 void publishStatusTimerEventHandler(const ros::TimerEvent& event);
@@ -509,16 +510,16 @@ void odometryHandler(const nav_msgs::Odometry::ConstPtr& message) {
 }
 
 // Allows a virtual fence to be defined and enabled or disabled through ROS
-void virtualFenceHandler(const std_msgs::Float32MultiArray& message) 
+void virtualFenceHandler(const swarmie_msgs::VirtualFence& message) 
 {
   // Read data from the message array
   // The first element is an integer indicating the shape type
   // 0 = Disable the virtual fence
   // 1 = circle
   // 2 = rectangle
-  int shape_type = static_cast<int>(message.data[0]); // Shape type
+  int cmd = static_cast<int>(message.cmd); // Shape type
   
-  if (shape_type == 0)
+  if (cmd == 0)
   {
     logicController.setVirtualFenceOff();
   }
@@ -526,24 +527,23 @@ void virtualFenceHandler(const std_msgs::Float32MultiArray& message)
   {
     // Elements 2 and 3 are the x and y coordinates of the range center
     Point center;
-    center.x = message.data[1]; // Range center x
-    center.y = message.data[2]; // Range center y
+    center.x = message.center_x; // Range center x
+    center.y = message.center_y; // Range center y
     
     // If the shape type is "circle" then element 4 is the radius, if rectangle then width
-    switch ( shape_type )
+    switch ( cmd )
     {
     case 1: // Circle
     {
-      if ( message.data.size() != 4 ) throw ROSAdapterRangeShapeInvalidTypeException("Wrong number of parameters for circle shape type in ROSAdapter.cpp:virtualFenceHandler()");
-      float radius = message.data[3]; 
-      logicController.setVirtualFenceOn( new RangeCircle(center, radius) );
+      //if ( message.data.size() != 4 ) throw ROSAdapterRangeShapeInvalidTypeException("Wrong number of parameters for circle shape type in ROSAdapter.cpp:virtualFenceHandler()");
+      //float radius = message.data; 
+      //logicController.setVirtualFenceOn( new RangeCircle(center, radius) );
       break;
     }
     case 2: // Rectangle 
     {
-      if ( message.data.size() != 5 ) throw ROSAdapterRangeShapeInvalidTypeException("Wrong number of parameters for rectangle shape type in ROSAdapter.cpp:virtualFenceHandler()");
-      float width = message.data[3]; 
-      float height = message.data[4]; 
+      float width = message.width; 
+      float height = message.height; 
       logicController.setVirtualFenceOn( new RangeRectangle(center, width, height) );
       break;
     }

--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -20,7 +20,6 @@
 #include <geometry_msgs/Twist.h>
 #include <nav_msgs/Odometry.h>
 #include <apriltags_ros/AprilTagDetectionArray.h>
-#include <std_msgs/Float32MultiArray.h>
 #include "swarmie_msgs/Waypoint.h"
 #include "swarmie_msgs/VirtualFence.h"
 
@@ -165,17 +164,17 @@ tf::TransformListener *tfListener;
 void sigintEventHandler(int signal);
 
 //Callback handlers
-void joyCmdHandler(const sensor_msgs::Joy::ConstPtr& message);
-void modeHandler(const std_msgs::UInt8::ConstPtr& message);
-void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& tagInfo);
-void odometryHandler(const nav_msgs::Odometry::ConstPtr& message);
-void mapHandler(const nav_msgs::Odometry::ConstPtr& message);
-void virtualFenceHandler(const swarmie_msgs::VirtualFence& message);
-void manualWaypointHandler(const swarmie_msgs::Waypoint& message);
-void behaviourStateMachine(const ros::TimerEvent&);
-void publishStatusTimerEventHandler(const ros::TimerEvent& event);
-void publishHeartBeatTimerEventHandler(const ros::TimerEvent& event);
-void sonarHandler(const sensor_msgs::Range::ConstPtr& sonarLeft, const sensor_msgs::Range::ConstPtr& sonarCenter, const sensor_msgs::Range::ConstPtr& sonarRight);
+void joyCmdHandler(const sensor_msgs::Joy::ConstPtr& message);			//for joystick control
+void modeHandler(const std_msgs::UInt8::ConstPtr& message);				//for detecting which mode the robot needs to be in
+void targetHandler(const apriltags_ros::AprilTagDetectionArray::ConstPtr& tagInfo);	//receives and stores April Tag Data using the TAG class
+void odometryHandler(const nav_msgs::Odometry::ConstPtr& message);			//receives and stores ODOM information
+void mapHandler(const nav_msgs::Odometry::ConstPtr& message);				//receives and stores GPS information
+void virtualFenceHandler(const swarmie_msgs::VirtualFence& message);		        //Used to set an invisible boundary for robots to keep them from traveling outside specific bounds
+void manualWaypointHandler(const swarmie_msgs::Waypoint& message);			//Receives a waypoint (from GUI) and sets the coordinates
+void behaviourStateMachine(const ros::TimerEvent&);					//Upper most state machine, calls logic controller to perform all actions
+void publishStatusTimerEventHandler(const ros::TimerEvent& event);			//Publishes "ONLINE" when rover is successfully connected
+void publishHeartBeatTimerEventHandler(const ros::TimerEvent& event);			
+void sonarHandler(const sensor_msgs::Range::ConstPtr& sonarLeft, const sensor_msgs::Range::ConstPtr& sonarCenter, const sensor_msgs::Range::ConstPtr& sonarRight);	//handles ultrasound data and stores data
 
 // Converts the time passed as reported by ROS (which takes Gazebo simulation rate into account) into milliseconds as an integer.
 long int getROSTimeInMilliSecs();

--- a/src/rqt_rover_gui/src/MapData.cpp
+++ b/src/rqt_rover_gui/src/MapData.cpp
@@ -13,7 +13,7 @@ void MapData::setVirtualFenceCircle(float center_x, float center_y, float radius
     update_mutex.lock();
     virtual_fence_center = pair<float,float>(center_x,center_y);
     virtual_fence_radius = radius;
-    virtual_fence_shape = CIRCLE;
+    virtual_fence_cmd = CIRCLE;
     update_mutex.unlock();
 }
 
@@ -23,7 +23,7 @@ void MapData::setVirtualFenceRectangle(float corner_x, float corner_y, float hei
     virtual_fence_corner = pair<float,float>(corner_x, corner_y);
     virtual_fence_height = height;
     virtual_fence_width = width;
-    virtual_fence_shape = RECTANGLE;
+    virtual_fence_cmd = RECTANGLE;
     update_mutex.unlock();
 }
 
@@ -260,9 +260,9 @@ std::tuple<float,float,float> MapData::getVirtualFenceCircle()
     return std::tuple<float,float,float>(virtual_fence_center.first, virtual_fence_center.second, virtual_fence_radius);
 }
 
-VirtualFenceShape MapData::getVirtualFenceShape()
+VirtualFenceCmd MapData::getVirtualFenceCmd()
 {
-    return virtual_fence_shape;
+    return virtual_fence_cmd;
 }
 
 std::vector< std::pair<float,float> >* MapData::getEKFPath(std::string rover_name)

--- a/src/rqt_rover_gui/src/MapData.cpp
+++ b/src/rqt_rover_gui/src/MapData.cpp
@@ -17,10 +17,10 @@ void MapData::setVirtualFenceCircle(float center_x, float center_y, float radius
     update_mutex.unlock();
 }
 
-void MapData::setVirtualFenceRect(float center_x, float center_y, float height, float width)
+void MapData::setVirtualFenceRectangle(float corner_x, float corner_y, float height, float width)
 {
     update_mutex.lock();
-    virtual_fence_center = pair<float,float>(center_x,center_y);
+    virtual_fence_corner = pair<float,float>(corner_x, corner_y);
     virtual_fence_height = height;
     virtual_fence_width = width;
     virtual_fence_shape = RECTANGLE;
@@ -250,9 +250,9 @@ void MapData::clear(string rover)
     update_mutex.unlock();
 }
 
-std::tuple<float,float,float,float> MapData::getVirtualFenceRect()
+std::tuple<float,float,float,float> MapData::getVirtualFenceRectangle()
 {
-    return std::tuple<float,float,float,float>(virtual_fence_center.first, virtual_fence_center.second, virtual_fence_height, virtual_fence_width);
+    return std::tuple<float,float,float,float>(virtual_fence_corner.first, virtual_fence_corner.second, virtual_fence_height, virtual_fence_width);
 }
 
 std::tuple<float,float,float> MapData::getVirtualFenceCircle()

--- a/src/rqt_rover_gui/src/MapData.cpp
+++ b/src/rqt_rover_gui/src/MapData.cpp
@@ -7,6 +7,26 @@ MapData::MapData()
     display_global_offset = false;
 }
 
+// Define virtual fences for display to the user.
+void MapData::setVirtualFenceCircle(float center_x, float center_y, float radius)
+{
+    update_mutex.lock();
+    virtual_fence_center = pair<float,float>(center_x,center_y);
+    virtual_fence_radius = radius;
+    virtual_fence_shape = CIRCLE;
+    update_mutex.unlock();
+}
+
+void MapData::setVirtualFenceRect(float center_x, float center_y, float height, float width)
+{
+    update_mutex.lock();
+    virtual_fence_center = pair<float,float>(center_x,center_y);
+    virtual_fence_height = height;
+    virtual_fence_width = width;
+    virtual_fence_shape = RECTANGLE;
+    update_mutex.unlock();
+}
+
 void MapData::addToGPSRoverPath(string rover, float x, float y)
 {
   // Negate the y direction to orient the map so up is north.
@@ -228,6 +248,21 @@ void MapData::clear(string rover)
     rover_mode.erase(rover);
 
     update_mutex.unlock();
+}
+
+std::tuple<float,float,float,float> MapData::getVirtualFenceRect()
+{
+    return std::tuple<float,float,float,float>(virtual_fence_center.first, virtual_fence_center.second, virtual_fence_height, virtual_fence_width);
+}
+
+std::tuple<float,float,float> MapData::getVirtualFenceCircle()
+{
+    return std::tuple<float,float,float>(virtual_fence_center.first, virtual_fence_center.second, virtual_fence_radius);
+}
+
+VirtualFenceShape MapData::getVirtualFenceShape()
+{
+    return virtual_fence_shape;
 }
 
 std::vector< std::pair<float,float> >* MapData::getEKFPath(std::string rover_name)

--- a/src/rqt_rover_gui/src/MapData.h
+++ b/src/rqt_rover_gui/src/MapData.h
@@ -30,11 +30,11 @@ public:
     // Define virtual fences (also called search range). The virtual fence constrains
     // Robot movement. They currently apply to all robots, though setting a different virtual
     // fence for each robot could be useful.
-    void setVirtualFenceRect(float center_x, float center_y, float height, float width);
+    void setVirtualFenceRectangle(float corner_x, float corner_y, float height, float width);
     void setVirtualFenceCircle(float center_x, float center_y, float radius);
 
     VirtualFenceShape getVirtualFenceShape();
-    std::tuple<float,float,float,float> getVirtualFenceRect();
+    std::tuple<float,float,float,float> getVirtualFenceRectangle();
     std::tuple<float,float,float> getVirtualFenceCircle();
 
     // Add a waypoint for the specified rover name
@@ -118,6 +118,7 @@ private:
     std::map<std::string, float> min_ekf_seen_x;
     std::map<std::string, float> min_ekf_seen_y;
 
+    std::pair<float,float> virtual_fence_corner;
     std::pair<float,float> virtual_fence_center;
     float virtual_fence_height = 0;
     float virtual_fence_width = 0;

--- a/src/rqt_rover_gui/src/MapData.h
+++ b/src/rqt_rover_gui/src/MapData.h
@@ -9,9 +9,8 @@
 #include <string>
 #include <QMutex>
 
-#include "MapData.h"
-
-enum VirtualFenceShape {UNDEFINED, CIRCLE, RECTANGLE};
+// Virtual fence command definitions that can be sent to the rover
+enum VirtualFenceCmd {UNDEFINED, CIRCLE, RECTANGLE};
 
 // This class is the "model" for std::map frame in the model-view UI pattern,
 // where std::mapFrame is the view.
@@ -33,7 +32,7 @@ public:
     void setVirtualFenceRectangle(float corner_x, float corner_y, float height, float width);
     void setVirtualFenceCircle(float center_x, float center_y, float radius);
 
-    VirtualFenceShape getVirtualFenceShape();
+    VirtualFenceCmd getVirtualFenceCmd();
     std::tuple<float,float,float,float> getVirtualFenceRectangle();
     std::tuple<float,float,float> getVirtualFenceCircle();
 
@@ -123,7 +122,7 @@ private:
     float virtual_fence_height = 0;
     float virtual_fence_width = 0;
     float virtual_fence_radius = 0;
-    VirtualFenceShape virtual_fence_shape = UNDEFINED;
+    VirtualFenceCmd virtual_fence_cmd = UNDEFINED;
 
     bool display_global_offset;
 

--- a/src/rqt_rover_gui/src/MapData.h
+++ b/src/rqt_rover_gui/src/MapData.h
@@ -11,6 +11,8 @@
 
 #include "MapData.h"
 
+enum VirtualFenceShape {UNDEFINED, CIRCLE, RECTANGLE};
+
 // This class is the "model" for std::map frame in the model-view UI pattern,
 // where std::mapFrame is the view.
 // This allows the creation of multiple std::maps without duplicating large amounts of std::map data.
@@ -24,6 +26,16 @@ public:
     void addToEKFRoverPath(std::string rover, float x, float y);
     void addTargetLocation(std::string rover, float x, float y);
     void addCollectionPoint(std::string rover, float x, float y);
+
+    // Define virtual fences (also called search range). The virtual fence constrains
+    // Robot movement. They currently apply to all robots, though setting a different virtual
+    // fence for each robot could be useful.
+    void setVirtualFenceRect(float center_x, float center_y, float height, float width);
+    void setVirtualFenceCircle(float center_x, float center_y, float radius);
+
+    VirtualFenceShape getVirtualFenceShape();
+    std::tuple<float,float,float,float> getVirtualFenceRect();
+    std::tuple<float,float,float> getVirtualFenceCircle();
 
     // Add a waypoint for the specified rover name
     // Returns the id of the waypoint. IDs are use to issue waypoint commands to the rover.
@@ -105,6 +117,12 @@ private:
     std::map<std::string, float> max_ekf_seen_y;
     std::map<std::string, float> min_ekf_seen_x;
     std::map<std::string, float> min_ekf_seen_y;
+
+    std::pair<float,float> virtual_fence_center;
+    float virtual_fence_height = 0;
+    float virtual_fence_width = 0;
+    float virtual_fence_radius = 0;
+    VirtualFenceShape virtual_fence_shape = UNDEFINED;
 
     bool display_global_offset;
 

--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -564,13 +564,17 @@ void MapFrame::paintEvent(QPaintEvent* event) {
         rectangle_fence.addRect(corner_x, corner_y, width, height);
         painter.drawPath(rectangle_fence);
 
-        float rectangle_center_x = corner_x+width/2;
-        float rectangle_center_y = corner_y+height/2;
-
         if (user_is_drawing_fence)
         {
-            painter.drawEllipse(QPointF(rectangle_center_x,rectangle_center_y), 2.5, 2.5);
-            QString rect_geometry = "Center: (" + QString::number(rectangle_center_x) + ", " + QString::number(rectangle_center_y) + ")\nWidth: " + QString::number(width) + "\nHeight: " + QString::number(height);
+            float rectangle_center_x = corner_x+width/2;
+            float rectangle_center_y = corner_y+width/2;
+            float meter_conversion_factor = max_seen_width/map_width; // Convert pixels into meters
+            float rectangle_center_x_in_meters = (corner_x+width/2) * meter_conversion_factor;
+            float rectangle_center_y_in_meters = (corner_y+height/2) * meter_conversion_factor;
+            float width_in_meters = abs(width * meter_conversion_factor); // abs because distances must be positive values
+            float height_in_meters = abs(height * meter_conversion_factor);
+            painter.drawEllipse(QPointF(rectangle_center_x_in_meters, rectangle_center_y_in_meters), 2.5, 2.5);
+            QString rect_geometry = "Center: (" + QString::number(rectangle_center_x_in_meters) + ", " + QString::number(rectangle_center_y_in_meters) + ")\nWidth: " + QString::number(width_in_meters)  + " m\nHeight: " + QString::number(height_in_meters) + " m";
             painter.drawText(QRect(rectangle_center_x, rectangle_center_y, 300, 200), rect_geometry);
         }
     }

--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -8,7 +8,6 @@
 #include <QGridLayout>
 #include <QLabel>
 #include <QMouseEvent>
-#include <MapData.h>
 #include "MapFrame.h"
 
 namespace rqt_rover_gui
@@ -534,7 +533,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
     hardware_rover_color_index = (hardware_rover_color_index + 1) % 8;
 
     // Draw the virtual fence
-    if (map_data->getVirtualFenceShape() == CIRCLE)
+    if (map_data->getVirtualFenceCmd() == CIRCLE)
     {
 
         painter.setPen(Qt::yellow);
@@ -549,7 +548,7 @@ void MapFrame::paintEvent(QPaintEvent* event) {
         //emit sendInfoLogMessage("Circular fence detected: Fence center: (" + QString::number(center_x) + ", " + QString::number(center_y) + "); Radius_x: " + QString::number(radius_x) + "Radius_y: " + QString::number(radius_y));
         painter.drawEllipse(center_x, center_y, radius_x, radius_y);
     }
-    else if (map_data->getVirtualFenceShape() == RECTANGLE)
+    else if (map_data->getVirtualFenceCmd() == RECTANGLE)
     {
         painter.setPen(Qt::yellow);
         tuple<float,float,float,float> virtual_fence = map_data->getVirtualFenceRectangle();

--- a/src/rqt_rover_gui/src/MapFrame.cpp
+++ b/src/rqt_rover_gui/src/MapFrame.cpp
@@ -564,6 +564,15 @@ void MapFrame::paintEvent(QPaintEvent* event) {
         rectangle_fence.addRect(corner_x, corner_y, width, height);
         painter.drawPath(rectangle_fence);
 
+        float rectangle_center_x = corner_x+width/2;
+        float rectangle_center_y = corner_y+height/2;
+
+        if (user_is_drawing_fence)
+        {
+            painter.drawEllipse(QPointF(rectangle_center_x,rectangle_center_y), 2.5, 2.5);
+            QString rect_geometry = "Center: (" + QString::number(rectangle_center_x) + ", " + QString::number(rectangle_center_y) + ")\nWidth: " + QString::number(width) + "\nHeight: " + QString::number(height);
+            painter.drawText(QRect(rectangle_center_x, rectangle_center_y, 300, 200), rect_geometry);
+        }
     }
 
     painter.setPen(Qt::white);

--- a/src/rqt_rover_gui/src/MapFrame.h
+++ b/src/rqt_rover_gui/src/MapFrame.h
@@ -27,6 +27,7 @@
 #include <utility> // For STL pair
 #include <map>
 #include <QString>
+#include "MapData.h"
 
 // Forward declarations
 class QMainWindow;
@@ -95,6 +96,7 @@ namespace rqt_rover_gui
 
     signals:
 
+      void sendVirtualFenceCmd(VirtualFenceCmd vf, float center_x, float center_y, float width, float height);
       void sendInfoLogMessage(QString msg);
       void sendWaypointCmd(WaypointCmd, int, float, float);
       void delayedUpdate();

--- a/src/rqt_rover_gui/src/MapFrame.h
+++ b/src/rqt_rover_gui/src/MapFrame.h
@@ -106,11 +106,18 @@ namespace rqt_rover_gui
         
     protected:
 
+      // React to draw requests
       void paintEvent(QPaintEvent *event);
+
+      // React to mouse events
       void mouseReleaseEvent(QMouseEvent *event);
       void mousePressEvent(QMouseEvent *event);
       void mouseMoveEvent(QMouseEvent *event);
       void wheelEvent(QWheelEvent *);
+
+      // React to keyboard events
+      void keyPressEvent(QKeyEvent* event);
+      void keyReleaseEvent(QKeyEvent* event);
 
     private:
 
@@ -184,6 +191,14 @@ namespace rqt_rover_gui
       
       float max_seen_width = -std::numeric_limits<float>::max();
       float max_seen_height = -std::numeric_limits<float>::max();
+
+      float fence_center_x = 0;
+      float fence_center_y = 0;
+      bool user_is_drawing_fence = false;
+
+      // Keyboard state
+      // This can be fooled when multiple shift keys are pressed or released at the same time.
+      bool shift_key_down = false;
 
       std::string rover_currently_selected; // This is the rover selected in the main GUI.
 

--- a/src/rqt_rover_gui/src/MapFrame.h
+++ b/src/rqt_rover_gui/src/MapFrame.h
@@ -192,8 +192,8 @@ namespace rqt_rover_gui
       float max_seen_width = -std::numeric_limits<float>::max();
       float max_seen_height = -std::numeric_limits<float>::max();
 
-      float fence_center_x = 0;
-      float fence_center_y = 0;
+      float fence_corner_x = 0;
+      float fence_corner_y = 0;
       bool user_is_drawing_fence = false;
 
       // Keyboard state

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -171,6 +171,9 @@ namespace rqt_rover_gui
     connect(ui.map_frame, SIGNAL(sendWaypointCmd(WaypointCmd, int, float, float)), this, SLOT(receiveWaypointCmd(WaypointCmd, int, float, float)));
     connect(this, SIGNAL(sendWaypointReached(int)), ui.map_frame, SLOT(receiveWaypointReached(int)));
     
+    // Receive virtual fence commands from MapFrame
+    connect(ui.map_frame, SIGNAL(sendVirtualFenceCmd(VirtualFenceCmd, float, float, float, float)), this, SLOT(receiveVirtualFenceCmd(VirtualFenceCmd, float, float, float, float)));
+
     // Receive log messages from contained frames
     connect(ui.map_frame, SIGNAL(sendInfoLogMessage(QString)), this, SLOT(receiveInfoLogMessage(QString)));
 
@@ -224,11 +227,14 @@ namespace rqt_rover_gui
     info_log_subscriber = nh.subscribe("/infoLog", 10, &RoverGUIPlugin::infoLogMessageEventHandler, this);
     diag_log_subscriber = nh.subscribe("/diagsLog", 10, &RoverGUIPlugin::diagLogMessageEventHandler, this);
 
+    virtualfence_cmd_publisher = nh.advertise<swarmie_msgs::VirtualFence>("/virtualFence/", 10, true);
+
     emit updateNumberOfSatellites("<font color='white'>---</font>");
   }
 
   void RoverGUIPlugin::shutdownPlugin()
   {
+    virtualfence_cmd_publisher.shutdown();
     map_data->clear(); // Clear the map and stop drawing before the map_frame is destroyed
     ui.map_frame->clear();
     clearSimulationButtonEventHandler();
@@ -779,6 +785,7 @@ void RoverGUIPlugin::pollRoversTimerEventHandler()
         // Delete Publishers
         control_mode_publishers.erase(*it);
         waypoint_cmd_publishers.erase(*it);
+
 
         ui.map_frame->resetWaypointPathForSelectedRover(*it);
     }
@@ -2964,6 +2971,24 @@ void RoverGUIPlugin::receiveWaypointCmd(WaypointCmd cmd, int id, float x, float 
     
     waypoint_cmd_publishers[selected_rover_name].publish(msg);
 }
+
+// Publish the virtual fence commands recieved from MapFrame to ROS
+void RoverGUIPlugin::receiveVirtualFenceCmd(VirtualFenceCmd cmd, float center_x, float center_y, float width, float height)
+{
+    sendInfoLogMessage("Virtual Fence Command Recieved");
+  
+    // At the moment there is only one global virtual fence topic that all rovers listen to
+    // Use the Virtual Fence custom message type to package up the command to publish. Relies on the VirtualFence enum matching the message definition.
+    swarmie_msgs::VirtualFence msg;
+    msg.cmd = cmd;
+    msg.center_x = center_x;
+    msg.center_y = center_y;
+    msg.width = width;
+    msg.height = height;
+
+    virtualfence_cmd_publisher.publish(msg);
+}
+
 
 // Clean up memory when this object is deleted
 RoverGUIPlugin::~RoverGUIPlugin()

--- a/src/rqt_rover_gui/src/rover_gui_plugin.h
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.h
@@ -52,6 +52,7 @@
 #include <mutex>
 #include <ublox_msgs/NavSOL.h>
 #include "swarmie_msgs/Waypoint.h" // For waypoint commands
+#include "swarmie_msgs/VirtualFence.h" // For virtual fence commands
 
 //ROS msg types
 //#include "rover_onboard_target_detection/ATag.h"
@@ -204,6 +205,11 @@ namespace rqt_rover_gui {
     void displayDiagLogMessage(QString msg);
     void receiveWaypointCmd(WaypointCmd, int, float, float);
 
+    // This slot recives parameters for building a virtual fence (aka range) command to send to rovers.
+    // The slot will publish the command to all known rovers.
+    void receiveVirtualFenceCmd(VirtualFenceCmd cmd, float center_x, float center_y, float width, float height);
+
+
     // Needed to refocus the keyboard events when the user clicks on the widget list
     // to the main widget so keyboard manual control is handled properly
     void refocusKeyboardEventHandler();
@@ -216,6 +222,7 @@ namespace rqt_rover_gui {
     // ROS Publishers
     map<string,ros::Publisher> control_mode_publishers;
     map<string,ros::Publisher> waypoint_cmd_publishers;
+    ros::Publisher virtualfence_cmd_publisher;
     ros::Publisher joystick_publisher;
 
     // ROS Subscribers

--- a/src/swarmie_msgs/CMakeLists.txt
+++ b/src/swarmie_msgs/CMakeLists.txt
@@ -46,6 +46,7 @@ find_package(catkin REQUIRED COMPONENTS message_generation)
 add_message_files(
   FILES
   Waypoint.msg
+  VirtualFence.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/swarmie_msgs/msg/VirtualFence.msg
+++ b/src/swarmie_msgs/msg/VirtualFence.msg
@@ -1,0 +1,9 @@
+# Defines the virtual fence's geometry
+uint32 DISABLE=0
+uint32 CIRCLE=1
+uint32 RECTANGLE=2
+uint32 cmd
+float32 center_x
+float32 center_y
+float32 width
+float32 height


### PR DESCRIPTION
This is an initial version with basic functionality. Holding shift and drawing in the map frame creates a virtual fence. 

1) In the future, we would like to add text boxes where the exact dimensions can be added rather than having to draw.
2) There is currently no way to remove a virtual fence once added without replacing it with another virtual fence.
3) There are cases where robots move out of the virtual fence in simulation. The most common is when two rovers collide and to avoid the collision they move outside the virtual fence.