### PR TITLE
fixed a bug where the default font size was incorrectly set

### DIFF
--- a/src/rqt_rover_gui/src/rover_gui_plugin.ui
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.ui
@@ -5255,8 +5255,11 @@ border: 1px solid white;
 padding: 1px 0px 1px 3px; /*This makes text colour work*/
 </string>
            </property>
+           <property name="currentText">
+            <string>15</string>
+           </property>
            <property name="currentIndex">
-            <number>0</number>
+            <number>10</number>
            </property>
            <property name="maxVisibleItems">
             <number>5</number>


### PR DESCRIPTION
The problem:

    The default font size in the font size combo box in the GUI
    was erroneously set to 5.

    The correct default size is actually set to 15. This results
    in extremely odd resizing behaviour whenever the user presses
    the font resize keys ('-'/'=').

The solution:

    The combobox default value was set to 15.

This bug fix is for issue #198 