### PR TITLE
updated the IMU frame to be scalable with the GUI

### DIFF
--- a/src/rqt_rover_gui/src/IMUFrame.cpp
+++ b/src/rqt_rover_gui/src/IMUFrame.cpp
@@ -21,7 +21,7 @@ IMUFrame::IMUFrame(QWidget *parent, Qt::WindowFlags flags) : QFrame(parent)
         // Make a test cube
         float center_x = this->width()/2;
         float center_y = this->height()/2;
-        float width_of_square = 100;
+        float width_of_square = 2*this->width()/3;
 
         cube[0] = make_tuple(width_of_square/2, -width_of_square/2, -width_of_square/2);
         cube[1] = make_tuple(width_of_square/2, width_of_square/2, -width_of_square/2);
@@ -97,14 +97,29 @@ void IMUFrame::rotateTimerEventHandler()
 
 void IMUFrame::paintEvent(QPaintEvent* event)
 {
-
     QPainter painter(this);
     painter.setPen(Qt::white);
     painter.setRenderHint(QPainter::Antialiasing, true);
 
     float center_x = this->width()/2;
-
     float center_y = this->height()/2;
+
+    // scale the size of the square with the current frame size dynamically;
+    // the width of the cube scales to the width or height of the frame,
+    // whichever one is smaller
+    float width_of_square = (this->width() < this->height()) ? (2*this->width()/3) : (2*this->height()/3);
+    cube[0] = make_tuple(-width_of_square/2, width_of_square/2, width_of_square/2);
+    cube[1] = make_tuple(-width_of_square/2, -width_of_square/2, width_of_square/2);
+    cube[2] = make_tuple(width_of_square/2, -width_of_square/2, width_of_square/2);
+    cube[3] = make_tuple(width_of_square/2, width_of_square/2, width_of_square/2);
+    cube[4] = make_tuple(-width_of_square/2, width_of_square/2, -width_of_square/2);
+    cube[5] = make_tuple(-width_of_square/2, -width_of_square/2, -width_of_square/2);
+    cube[6] = make_tuple(width_of_square/2, -width_of_square/2, -width_of_square/2);
+    cube[7] = make_tuple(width_of_square/2, width_of_square/2, -width_of_square/2);
+    line1_start = make_tuple(-width_of_square/2, 0, 0);
+    line2_start = make_tuple(width_of_square/2, 0, 0);
+    line1_end = make_tuple(-width_of_square, 0, 0);
+    line2_end = make_tuple(width_of_square, 0, 0);
 
     // Track the frames per second for development purposes
     QString frames_per_second;

--- a/src/rqt_rover_gui/src/IMUFrame.h
+++ b/src/rqt_rover_gui/src/IMUFrame.h
@@ -33,6 +33,7 @@ namespace rqt_rover_gui
 class IMUFrame : public QFrame
 {
     Q_OBJECT
+
 public:
     IMUFrame(QWidget *parent, Qt::WindowFlags = 0);
     void setLinearAcceleration(float x, float y, float z);
@@ -40,15 +41,12 @@ public:
     void setOrientation(float w, float x, float y, float z);
 
 signals:
-
     void delayedUpdate();
 
 public slots:
     void rotateTimerEventHandler();
 
-
 protected:
-
     void paintEvent(QPaintEvent *event);
 
 private:
@@ -56,7 +54,7 @@ private:
     tuple<float, float, float> rotateByQuaternion( tuple<float, float, float> point,  tuple<float, float, float, float> quaternion);
     tuple<float, float, float> inverseRotateByQuaternion( tuple<float, float, float> point,  tuple<float, float, float, float> quaternion);
     tuple<float, float, float> rotateAboutAxis(tuple<float, float, float> point, float angle,  tuple<float, float, float> axis_of_rotation);
-    float** setUpRotationMatrix(float angle, tuple<float, float, float> axis_rotation); // angle in radians   
+    float** setUpRotationMatrix(float angle, tuple<float, float, float> axis_rotation); // angle in radians
 
     tuple<float, float, float> linear_acceleration; // ROS Geometry Messages Vector3: <x, y, z>
     tuple<float, float, float> angular_velocity; // ROS Geometry Messages Vector3: <x, y, z>


### PR DESCRIPTION
The problem:

    The cube representing the IMU data would not scale in size
    with changes to the size of the GUI window.

The solution:

    The eight (x,y,z) points representing the corners of the cube
    stored in the "cube[]" variable are now updated with a new
    "width_of_square" value during each paint event.

    Also, the coordinates for the lines drawn from the cube are
    also updated (line1 and line2).

The caveats:

    The initial square drawn when the GUI is launched will NOT
    resize... I have been unable to determine why this is the case;
    especially since, for example, the ultrasound frame DOES
    resize and both class implementations of QFrame are identical.

    However, once a rover is selected, the IMU graphic resizes
    appropriately.

This pull request addresses issue #200 