### PR TITLE
fixed a bug where the custom world button doesn't disable properly

### DIFF
--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -2071,13 +2071,14 @@ void RoverGUIPlugin::buildSimulationButtonEventHandler()
     //sim_mgr.startGazeboClient();
 
     ui.visualize_simulation_button->setEnabled(true);
-    ui.clear_simulation_button->setEnabled(true);
-
     ui.visualize_simulation_button->setStyleSheet("color: white;border:1px solid white; border-radius:12px; padding: 5px;");
+    ui.clear_simulation_button->setEnabled(true);
     ui.clear_simulation_button->setStyleSheet("color: white;border:1px solid white; border-radius:12px; padding: 5px;");
-
     ui.simulation_timer_combobox->setEnabled(true);
     ui.simulation_timer_combobox->setStyleSheet("color: white; border:1px solid white; padding: 1px 0px 1px 3px");
+    ui.custom_world_path_button->setEnabled(false);
+    ui.custom_world_path_button->setStyleSheet("color: grey;border:1px solid grey; border-radius:12px; padding: 5px;");
+    ui.custom_world_path->setStyleSheet("color: grey;");
 
     emit sendInfoLogMessage("Finished building simulation.");
 
@@ -2216,9 +2217,11 @@ void RoverGUIPlugin::clearSimulationButtonEventHandler()
     ui.visualize_simulation_button->setEnabled(false);
     ui.build_simulation_button->setEnabled(true);
     ui.clear_simulation_button->setEnabled(false);
+    ui.custom_world_path_button->setEnabled(true);
     display_sim_visualization = false;
 
-
+    ui.custom_world_path_button->setStyleSheet("color: white;border:1px solid white; border-radius:12px; padding: 5px;");
+    ui.custom_world_path->setStyleSheet("color: white;");
     ui.build_simulation_button->setStyleSheet("color: white; border:1px solid white; border-radius:12px; padding: 5px;");
     ui.visualize_simulation_button->setStyleSheet("color: grey; border:2px solid grey; border-radius:12px; padding: 5px;");
     ui.clear_simulation_button->setStyleSheet("color: grey; border:2px solid grey; border-radius:12px; padding: 5px;");

--- a/src/rqt_rover_gui/src/rover_gui_plugin.ui
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.ui
@@ -2463,7 +2463,7 @@ border-radius: 12px;
                     </widget>
                    </item>
                    <item>
-                    <widget class="QFrame" name="frame_21">
+                    <widget class="QFrame" name="custom_world_frame">
                      <property name="frameShape">
                       <enum>QFrame::NoFrame</enum>
                      </property>


### PR DESCRIPTION
The problem:

    The select custom world button and file path display stay
    interactive even after starting a simulation; this behaviour
    is undesirable and un-intuitive to how the interaction is
    supposed to work.

The solution:

    The GUI has been updated to properly disable/enable this button
    after clicking "build simulation" and "end simulation".

This pull request addresses issue #142 