### PR TITLE
Reduce gripper wrist and finger joint damping values.

### DIFF
--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -301,7 +301,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -382,7 +382,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -463,7 +463,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -320,7 +320,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -401,7 +401,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -482,7 +482,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -320,7 +320,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.5</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -401,7 +401,7 @@
 					<lower>0.0</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>
@@ -482,7 +482,7 @@
 					<lower>-0.7854</lower>
 				</limit>
 				<dynamics>
-				  <damping>0.3</damping>
+				  <damping>0.07</damping>
 				</dynamics>
 			</axis>
 		</joint>


### PR DESCRIPTION
Addresses issue  #204 

http://gazebosim.org/tutorials/?tut=ros_urdf#Joints
The damping element adds a viscous damping coefficient to oppose the joint velocity. Reducing it speeds up the wrist and finger movements to more realistic speeds.