### PR TITLE
Added additional logic to reset the obstacle_call_count for timed runs

### DIFF
--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -1560,6 +1560,7 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             is_timer_on = true;
             // reset the obstacle_call_count for this timed run
             obstacle_call_count = 0;
+            emit updateObstacleCallCount("<font color='white'>"+QString::number(obstacle_call_count)+"</font>");
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1584,6 +1585,7 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             is_timer_on = true;
             // reset the obstacle_call_count for this timed run
             obstacle_call_count = 0;
+            emit updateObstacleCallCount("<font color='white'>"+QString::number(obstacle_call_count)+"</font>");
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1608,6 +1610,7 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             is_timer_on = true;
             // reset the obstacle_call_count for this timed run
             obstacle_call_count = 0;
+            emit updateObstacleCallCount("<font color='white'>"+QString::number(obstacle_call_count)+"</font>");
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1632,6 +1635,7 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             is_timer_on = true;
             // reset the obstacle_call_count for this timed run
             obstacle_call_count = 0;
+            emit updateObstacleCallCount("<font color='white'>"+QString::number(obstacle_call_count)+"</font>");
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +

--- a/src/rqt_rover_gui/src/rover_gui_plugin.cpp
+++ b/src/rqt_rover_gui/src/rover_gui_plugin.cpp
@@ -1558,6 +1558,8 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 600.0;
             is_timer_on = true;
+            // reset the obstacle_call_count for this timed run
+            obstacle_call_count = 0;
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1580,6 +1582,8 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 1200.0;
             is_timer_on = true;
+            // reset the obstacle_call_count for this timed run
+            obstacle_call_count = 0;
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1602,6 +1606,8 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 1800.0;
             is_timer_on = true;
+            // reset the obstacle_call_count for this timed run
+            obstacle_call_count = 0;
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +
@@ -1624,6 +1630,8 @@ void RoverGUIPlugin::allAutonomousButtonEventHandler()
             timer_start_time_in_seconds = current_simulated_time_in_seconds;
             timer_stop_time_in_seconds = timer_start_time_in_seconds + 3600.0;
             is_timer_on = true;
+            // reset the obstacle_call_count for this timed run
+            obstacle_call_count = 0;
             emit sendInfoLogMessage("\nSetting experiment timer to start at: " +
                                     QString::number(getHours(timer_start_time_in_seconds)) + " hours, " +
                                     QString::number(getMinutes(timer_start_time_in_seconds)) + " minutes, " +


### PR DESCRIPTION
The Problem:
    When running timed simulation runs, the obstacle avoidance call
    count continues to accumulate for the entire duration of a sim
    and not just for a timed run.

The Solution:
    In the logic where a timed run is initiated, the obstacle avoidance
    count is reset to 0.