### PR TITLE
Use a custom message for commanding the robot motors.

### DIFF
--- a/src/abridge/CMakeLists.txt
+++ b/src/abridge/CMakeLists.txt
@@ -8,10 +8,11 @@ find_package(catkin REQUIRED COMPONENTS
   std_msgs
   tf
   nav_msgs
+  swarmie_msgs
 )
 
 catkin_package(
-  CATKIN_DEPENDS geometry_msgs roscpp sensor_msgs std_msgs tf nav_msgs
+  CATKIN_DEPENDS geometry_msgs roscpp sensor_msgs std_msgs tf nav_msgs swarmie_msgs
 )
 
 include_directories(

--- a/src/abridge/package.xml
+++ b/src/abridge/package.xml
@@ -15,6 +15,7 @@
   <build_depend>std_msgs</build_depend>
   <build_depend>tf</build_depend>
   <build_depend>nav_msgs</build_depend>
+  <build_depend>swarmie_msgs</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -22,6 +23,7 @@
   <run_depend>std_msgs</run_depend>
   <run_depend>tf</run_depend>
   <run_depend>nav_msgs</run_depend>
+  <run_depend>swarmie_msgs</run_depend>
 
   <export>
 

--- a/src/abridge/src/abridge.cpp
+++ b/src/abridge/src/abridge.cpp
@@ -14,13 +14,15 @@
 #include <sensor_msgs/Range.h>
 #include <std_msgs/UInt8.h>
 
+#include <swarmie_msgs/Skid.h>
+
 //Package include
 #include <usbSerial.h>
 
 using namespace std;
 
 //aBridge functions
-void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message);
+void driveCommandHandler(const swarmie_msgs::Skid::ConstPtr& message);
 void fingerAngleHandler(const std_msgs::Float32::ConstPtr& angle);
 void wristAngleHandler(const std_msgs::Float32::ConstPtr& angle);
 void serialActivityTimer(const ros::TimerEvent& e);
@@ -160,14 +162,12 @@ int main(int argc, char **argv)
   return EXIT_SUCCESS;
 }
 
-//This command handler recives a linear velocity setpoint and a angular yaw error
-//and produces a command output for the left and right motors of the robot.
-//See the following paper for description of PID controllers.
-//Bennett, Stuart (November 1984). "Nicholas Minorsky and the automatic steering of ships". IEEE Control Systems Magazine. 4 (4): 10–15. doi:10.1109/MCS.1984.1104827. ISSN 0272-1708.
-void driveCommandHandler(const geometry_msgs::Twist::ConstPtr& message)
+// Receives a left/right skid steer command to set the left and right
+// PWM control for the robot wheels
+void driveCommandHandler(const swarmie_msgs::Skid::ConstPtr& message)
 {
-  float left = (message->linear.x); // Target linear velocity in meters per second
-  float right = (message->angular.z); // Angular error in radians
+  float left = message->left;
+  float right = message->right;
 
   // Cap motor commands at 120. Experimentally determined that high values (tested 180 and 255) can cause 
   // the hardware to fail when the robot moves itself too violently.

--- a/src/behaviours/src/ROSAdapter.cpp
+++ b/src/behaviours/src/ROSAdapter.cpp
@@ -23,6 +23,7 @@
 #include <std_msgs/Float32MultiArray.h>
 #include "swarmie_msgs/Waypoint.h"
 #include "swarmie_msgs/Recruitment.h"
+#include "swarmie_msgs/Skid.h"
 
 // Include Controllers
 #include "LogicController.h"
@@ -120,7 +121,6 @@ Result result;		//result struct for passing and storing values to drive robot
 std_msgs::String msg;	//used for passing messages to the GUI
 
 
-geometry_msgs::Twist velocity;
 char host[128];		//rovers hostname
 string publishedName;	//published hostname
 char prev_state_machine[128];
@@ -228,7 +228,7 @@ int main(int argc, char **argv) {
   fingerAnglePublish = mNH.advertise<std_msgs::Float32>((publishedName + "/fingerAngle/cmd"), 1, true);			//publishes gripper angle to move gripper finger
   wristAnglePublish = mNH.advertise<std_msgs::Float32>((publishedName + "/wristAngle/cmd"), 1, true);			//publishes wrist angle to move wrist
   infoLogPublisher = mNH.advertise<std_msgs::String>("/infoLog", 1, true);						//publishes a message to the infolog box on GUI
-  driveControlPublish = mNH.advertise<geometry_msgs::Twist>((publishedName + "/driveControl"), 10);			//publishes motor commands to the motors
+  driveControlPublish = mNH.advertise<swarmie_msgs::Skid>((publishedName + "/driveControl"), 10);			//publishes motor commands to the motors
   heartbeatPublisher = mNH.advertise<std_msgs::String>((publishedName + "/behaviour/heartbeat"), 1, true);		//publishes ROSAdapters status via its "heartbeat"
   waypointFeedbackPublisher = mNH.advertise<swarmie_msgs::Waypoint>((publishedName + "/waypoints"), 1, true);		//publishes a waypoint to travel to if the rover is given a waypoint in manual mode
 
@@ -434,11 +434,11 @@ void behaviourStateMachine(const ros::TimerEvent&)
 
 void sendDriveCommand(double left, double right)
 {
-  velocity.linear.x = left,
-      velocity.angular.z = right;
-  
+  swarmie_msgs::Skid skid_command;
+  skid_command.left  = left;
+  skid_command.right = right;
   // publish the drive commands
-  driveControlPublish.publish(velocity);
+  driveControlPublish.publish(skid_command);
 }
 
 /*************************

--- a/src/sbridge/CMakeLists.txt
+++ b/src/sbridge/CMakeLists.txt
@@ -5,10 +5,11 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   roscpp
   std_msgs
+  swarmie_msgs
 )
 
 catkin_package(
-  CATKIN_DEPENDS geometry_msgs roscpp std_msgs
+  CATKIN_DEPENDS geometry_msgs roscpp std_msgs swarmie_msgs
 )
 
 include_directories(

--- a/src/sbridge/package.xml
+++ b/src/sbridge/package.xml
@@ -16,6 +16,7 @@
   <build_depend>std_msgs</build_depend>
   <!--<build_depend>tf</build_depend>-->
   <!--<build_depend>nav_msgs</build_depend>-->
+  <build_depend>swarmie_msgs</build_depend>
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>roscpp</run_depend>
@@ -23,6 +24,7 @@
   <run_depend>std_msgs</run_depend>
   <!--<run_depend>tf</run_depend>-->
   <!--<run_depend>nav_msgs</run_depend>-->
+  <run_depend>swarmie_msgs</run_depend>
 
   <export>
 

--- a/src/sbridge/src/sbridge.cpp
+++ b/src/sbridge/src/sbridge.cpp
@@ -49,12 +49,12 @@ sbridge::sbridge(std::string published_name)
 
 // Command Handler
 // PWM (pulse with modulation) values to linear values
-void sbridge::cmdHandler(const geometry_msgs::Twist::ConstPtr& message)
+void sbridge::cmdHandler(const swarmie_msgs::Skid::ConstPtr& message)
 {
-  // Gets and sets the linear PWM value
-  double left = (message->linear.x);
-  // Gets and sets the angular PWM value
-  double right = (message->angular.z);
+  // Gets and sets the left PWM value
+  double left = message->left;
+  // Gets and sets the right PWM value
+  double right = message->right;
     
   // Set max values
   float max_turn_rate = 4.5; // radians per second

--- a/src/sbridge/src/sbridge.h
+++ b/src/sbridge/src/sbridge.h
@@ -10,6 +10,8 @@
 #include <geometry_msgs/Twist.h>
 #include <std_msgs/UInt8.h>
 
+#include <swarmie_msgs/Skid.h>
+
 using namespace std;
 
 /**
@@ -21,7 +23,7 @@ class sbridge {
 public:
 
   sbridge(std::string published_name);
-  void cmdHandler(const geometry_msgs::Twist::ConstPtr& message);
+  void cmdHandler(const swarmie_msgs::Skid::ConstPtr& message);
   ~sbridge();
 
 private:

--- a/src/swarmie_msgs/CMakeLists.txt
+++ b/src/swarmie_msgs/CMakeLists.txt
@@ -47,6 +47,7 @@ add_message_files(
   FILES
   Waypoint.msg
   Recruitment.msg
+  Skid.msg
 )
 
 ## Generate services in the 'srv' folder

--- a/src/swarmie_msgs/msg/Skid.msg
+++ b/src/swarmie_msgs/msg/Skid.msg
@@ -1,0 +1,2 @@
+float32 left
+float32 right


### PR DESCRIPTION
Instead of abusing the Twist message we now use a Skid message that
explicitly contains a left motor command and a right motor command.