### PR TITLE
Increase pause to allow roscore to start

### DIFF
--- a/misc/run_calibration.sh
+++ b/misc/run_calibration.sh
@@ -19,7 +19,7 @@ full_path=repo_path
 
 #Start ROS core for ros serial
 roscore &
-sleep 1
+sleep 10
 rosrun rosserial_python serial_node.py _baud:=9600 $arduino_port &
 sleep 1
 


### PR DESCRIPTION
1 second allows for a race condition. This change still allows for a race, but makes it much less likely.