### PR TITLE
Improved wheel dynamics

### DIFF
--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/swarmie/model.sdf.erb
+++ b/simulation/models/swarmie/model.sdf.erb
@@ -531,6 +531,12 @@ wheel_config = {
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<%- end -%>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -527,6 +527,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_front_wheel">
@@ -579,6 +585,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="left_rear_wheel">
@@ -631,6 +643,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 		<link name="right_rear_wheel">
@@ -683,6 +701,12 @@
 			<axis>
 				<xyz>0 1 0</xyz>
 			</axis>
+			<physics>
+				<ode>
+					<cfm>0.01</cfm>
+					<erp>0.8</erp>
+				</ode>
+			</physics>
 		</joint>
 
 


### PR DESCRIPTION
See PR #243. This pull request supersedes the earlier one since we are using templated model files now. Thanks to @darrenchurchill. 

"I settled on a very small Constraint Force Mixing parameter (0.01), to soften the wheel joints slightly, and a greatly increased the Error Reduction Parameter (0.8), so the wheels move quickly back to their normal positions in just a few physics iterations if they get slightly out of place.

The CFM is small enough so there shouldn't be any 'suspension' effect or vibration in the model when it comes to a stop."