### PR TITLE
Gazebo sonar plugin

### DIFF
--- a/simulation/models/achilles/model.sdf
+++ b/simulation/models/achilles/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/achilles/sonarLeft</topicName>
-					<frameId>achilles/us_left_link</frameId>
+					<frameName>achilles/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/achilles/sonarRight</topicName>
-					<frameId>achilles/us_right_link</frameId>
+					<frameName>achilles/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/achilles/sonarCenter</topicName>
-					<frameId>achilles/us_center_link</frameId>
+					<frameName>achilles/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/aeneas/model.sdf
+++ b/simulation/models/aeneas/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/aeneas/sonarLeft</topicName>
-					<frameId>aeneas/us_left_link</frameId>
+					<frameName>aeneas/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/aeneas/sonarRight</topicName>
-					<frameId>aeneas/us_right_link</frameId>
+					<frameName>aeneas/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/aeneas/sonarCenter</topicName>
-					<frameId>aeneas/us_center_link</frameId>
+					<frameName>aeneas/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/ajax/model.sdf
+++ b/simulation/models/ajax/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/ajax/sonarLeft</topicName>
-					<frameId>ajax/us_left_link</frameId>
+					<frameName>ajax/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/ajax/sonarRight</topicName>
-					<frameId>ajax/us_right_link</frameId>
+					<frameName>ajax/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/ajax/sonarCenter</topicName>
-					<frameId>ajax/us_center_link</frameId>
+					<frameName>ajax/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/diomedes/model.sdf
+++ b/simulation/models/diomedes/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/diomedes/sonarLeft</topicName>
-					<frameId>diomedes/us_left_link</frameId>
+					<frameName>diomedes/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/diomedes/sonarRight</topicName>
-					<frameId>diomedes/us_right_link</frameId>
+					<frameName>diomedes/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/diomedes/sonarCenter</topicName>
-					<frameId>diomedes/us_center_link</frameId>
+					<frameName>diomedes/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/hector/model.sdf
+++ b/simulation/models/hector/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/hector/sonarLeft</topicName>
-					<frameId>hector/us_left_link</frameId>
+					<frameName>hector/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/hector/sonarRight</topicName>
-					<frameId>hector/us_right_link</frameId>
+					<frameName>hector/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/hector/sonarCenter</topicName>
-					<frameId>hector/us_center_link</frameId>
+					<frameName>hector/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/paris/model.sdf
+++ b/simulation/models/paris/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/paris/sonarLeft</topicName>
-					<frameId>paris/us_left_link</frameId>
+					<frameName>paris/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/paris/sonarRight</topicName>
-					<frameId>paris/us_right_link</frameId>
+					<frameName>paris/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/paris/sonarCenter</topicName>
-					<frameId>paris/us_center_link</frameId>
+					<frameName>paris/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/swarmie/model.sdf.erb
+++ b/simulation/models/swarmie/model.sdf.erb
@@ -30,19 +30,20 @@ sonar_frames = {
 us_x = 0.15
 us_y = 0.07
 us_z = 0.053
+us_pitch = -1.5708
 us_yaw = 0.43633
 
 sonar_config = {
   "left" => {
-    :x0 => us_x, :y0 => us_y, :z0 => us_z, :yaw => us_yaw,
+    :x0 => us_x, :y0 => us_y, :z0 => us_z, :pitch => us_pitch, :yaw => us_yaw,
     :topic => "/" + rovername + "/sonarLeft", :frame => sonar_frames["left"]
   },
   "right" => {
-    :x0 => us_x, :y0 => -us_y, :z0 => us_z, :yaw => -us_yaw,
+    :x0 => us_x, :y0 => -us_y, :z0 => us_z, :pitch => us_pitch, :yaw => -us_yaw,
     :topic => "/" + rovername + "/sonarRight", :frame => sonar_frames["right"]
   },
   "center" => {
-    :x0 => us_x, :y0 => 0, :z0 => us_z, :yaw => 0,
+    :x0 => us_x, :y0 => 0, :z0 => us_z, :pitch => us_pitch, :yaw => 0,
     :topic => "/" + rovername + "/sonarCenter", :frame => sonar_frames["center"]
   }
 }
@@ -154,33 +155,25 @@ wheel_config = {
 					x0 = sonar_config[key][:x0]
 					y0 = sonar_config[key][:y0]
 					z0 = sonar_config[key][:z0]
+					pitch = sonar_config[key][:pitch]
 					yaw = sonar_config[key][:yaw]
 					topic = sonar_config[key][:topic]
 					frame = sonar_config[key][:frame]
 			-%>
-			<sensor type="ray" name="<%= 'us_' + key + '_sensor' %>">
-				<pose><%= x0 %> <%= y0 %> <%= z0 %> 0 0 <%= yaw %></pose>
+			<sensor type="sonar" name="<%= 'us_' + key + '_sensor' %>">
+				<pose><%= x0 %> <%= y0 %> <%= z0 %> 0 <%= pitch %> <%= yaw %></pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName><%= topic %></topicName>
-					<frameId><%= frame %></frameId>
+					<frameName><%= frame %></frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 			<%- end -%>

--- a/simulation/models/thor/model.sdf
+++ b/simulation/models/thor/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/thor/sonarLeft</topicName>
-					<frameId>thor/us_left_link</frameId>
+					<frameName>thor/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/thor/sonarRight</topicName>
-					<frameId>thor/us_right_link</frameId>
+					<frameName>thor/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/thor/sonarCenter</topicName>
-					<frameId>thor/us_center_link</frameId>
+					<frameName>thor/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/simulation/models/zeus/model.sdf
+++ b/simulation/models/zeus/model.sdf
@@ -46,79 +46,52 @@
 				</material>
 			</visual>
 
-			<sensor type="ray" name="us_left_sensor">
-				<pose>0.15 0.07 0.053 0 0 0.43633</pose>
+			<sensor type="sonar" name="us_left_sensor">
+				<pose>0.15 0.07 0.053 0 -1.5708 0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/zeus/sonarLeft</topicName>
-					<frameId>zeus/us_left_link</frameId>
+					<frameName>zeus/us_left_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_right_sensor">
-				<pose>0.15 -0.07 0.053 0 0 -0.43633</pose>
+			<sensor type="sonar" name="us_right_sensor">
+				<pose>0.15 -0.07 0.053 0 -1.5708 -0.43633</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/zeus/sonarRight</topicName>
-					<frameId>zeus/us_right_link</frameId>
+					<frameName>zeus/us_right_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
-			<sensor type="ray" name="us_center_sensor">
-				<pose>0.15 0 0.053 0 0 0</pose>
+			<sensor type="sonar" name="us_center_sensor">
+				<pose>0.15 0 0.053 0 -1.5708 0</pose>
 				<visualize>false</visualize>
 				<update_rate>5</update_rate>
-				<ray>
-					<scan>
-						<horizontal>
-							<samples>3</samples>
-							<resolution>1.0</resolution>
-							<min_angle>-.478</min_angle>
-							<max_angle>0.478</max_angle>
-						</horizontal>
-					</scan>
-					<range>
-						<min>0.010</min>
-						<max>3</max>
-						<resolution>0.01</resolution>
-					</range>
-				</ray>
-				<plugin name="us" filename="libhector_gazebo_ros_sonar.so">
-					<gaussianNoise>0.005</gaussianNoise>
+				<sonar>
+					<min>0.01</min>
+					<max>3.0</max>
+					<radius>0.5</radius>
+				</sonar>
+				<plugin name="us" filename="libgazebo_plugins_sonar.so">
+					<gaussianNoise>0.15</gaussianNoise>
 					<topicName>/zeus/sonarCenter</topicName>
-					<frameId>zeus/us_center_link</frameId>
+					<frameName>zeus/us_center_link</frameName>
+					<fov>0.5</fov>
 				</plugin>
 			</sensor>
 

--- a/src/gazebo_plugins/CMakeLists.txt
+++ b/src/gazebo_plugins/CMakeLists.txt
@@ -33,3 +33,6 @@ add_library(${PROJECT_NAME}_score
 
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 
+add_library(${PROJECT_NAME}_sonar
+  src/SonarPlugin/gazebo_ros_sonar.cpp)
+target_link_libraries(${PROJECT_NAME}_sonar ${catkin_LIBRARIES} ${Boost_LIBRARIES} SonarPlugin)

--- a/src/gazebo_plugins/src/SonarPlugin/gazebo_ros_sonar.cpp
+++ b/src/gazebo_plugins/src/SonarPlugin/gazebo_ros_sonar.cpp
@@ -1,0 +1,256 @@
+/*
+ * Software License Agreement (Modified BSD License)
+ *
+ *  Copyright (c) 2013-2015, PAL Robotics, S.L.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PAL Robotics, S.L. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Jose Capriles, Bence Magyar, Moussab Bennehar. */
+
+#include <algorithm>
+#include <string>
+#include <assert.h>
+
+#include <gazebo/physics/World.hh>
+#include <gazebo/physics/HingeJoint.hh>
+#include <gazebo/sensors/Sensor.hh>
+#include <sdf/sdf.hh>
+#include <sdf/Param.hh>
+#include <gazebo/common/Exception.hh>
+#include <gazebo/sensors/SonarSensor.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/transport/transport.hh>
+
+#include <tf/tf.h>
+#include <tf/transform_listener.h>
+
+#include "gazebo_ros_sonar.h"
+
+namespace gazebo
+{
+// Register this plugin with the simulator
+GZ_REGISTER_SENSOR_PLUGIN(GazeboRosSonar)
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosSonar::GazeboRosSonar()
+{
+  this->seed = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosSonar::~GazeboRosSonar()
+{
+  this->rosnode_->shutdown();
+  delete this->rosnode_;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosSonar::Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf)
+{
+  // load plugin
+  SonarPlugin::Load(_parent, this->sdf);
+  // Get the world name.
+  std::string worldName = _parent->WorldName();
+  this->world_ = physics::get_world(worldName);
+  // save pointers
+  this->sdf = _sdf;
+
+  this->last_update_time_ = common::Time(0);
+
+  GAZEBO_SENSORS_USING_DYNAMIC_POINTER_CAST;
+  this->parent_sonar_sensor_ =      
+    dynamic_pointer_cast<sensors::SonarSensor>(_parent);
+
+  if (!this->parent_sonar_sensor_)
+    gzthrow("GazeboRosSonar controller requires a Sonar Sensor as its parent");
+
+  this->robot_namespace_ =  GetRobotNamespace(_parent, _sdf, "Sonar");
+    
+  if (!this->sdf->HasElement("frameName"))
+  {
+    ROS_INFO_NAMED("range", "Range plugin missing <frameName>, defaults to /world");
+    this->frame_name_ = "/world";
+  }
+  else
+    this->frame_name_ = this->sdf->Get<std::string>("frameName");
+
+  ROS_INFO("#########    frame name : %s  #############", this->frame_name_.c_str());
+
+  if (!this->sdf->HasElement("topicName"))
+  {
+    ROS_INFO_NAMED("sonar", "Sonar plugin missing <topicName>, defaults to /sonar");
+    this->topic_name_ = "/sonar";
+  }
+  else
+    this->topic_name_ = this->sdf->Get<std::string>("topicName");
+
+  if (!this->sdf->HasElement("fov"))
+  {
+      ROS_WARN_NAMED("sonar", "Sonar plugin missing <fov>, defaults to 0.05");
+      this->fov_ = 0.05;
+  }
+  else
+      this->fov_ = _sdf->GetElement("fov")->Get<double>();
+
+  if (!this->sdf->HasElement("gaussianNoise"))
+  {
+    ROS_INFO_NAMED("sonar", "Sonar plugin missing <gaussianNoise>, defaults to 0.0");
+    this->gaussian_noise_ = 0;
+  }
+  else
+    this->gaussian_noise_ = this->sdf->Get<double>("gaussianNoise");
+
+  this->sonar_connect_count_ = 0;
+
+  // Make sure the ROS node for Gazebo has already been initialized
+  if (!ros::isInitialized())
+  {
+    ROS_FATAL_STREAM_NAMED("sonar", "A ROS node for Gazebo has not been initialized, unable to load plugin. "
+      << "Load the Gazebo system plugin 'libgazebo_ros_api_plugin.so' in the gazebo_ros package)");
+    return;
+  }
+
+  ROS_INFO_NAMED("sonar", "Starting Sonar Plugin (ns = %s)", this->robot_namespace_.c_str() );
+  // ros callback queue for processing subscription
+  this->deferred_load_thread_ = boost::thread(
+    boost::bind(&GazeboRosSonar::LoadThread, this));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosSonar::LoadThread()
+{
+  this->gazebo_node_ = gazebo::transport::NodePtr(new gazebo::transport::Node());
+  this->gazebo_node_->Init(this->world_name_);
+
+  this->pmq.startServiceThread();
+
+  this->rosnode_ = new ros::NodeHandle(this->robot_namespace_);
+
+
+  this->tf_prefix_ = tf::getPrefixParam(*this->rosnode_);
+  if(this->tf_prefix_.empty()) {
+      this->tf_prefix_ = this->robot_namespace_;
+      boost::trim_right_if(this->tf_prefix_,boost::is_any_of("/"));
+  }
+  ROS_INFO_NAMED("sonar", "Sonar Plugin (ns = %s)  <tf_prefix_>, set to \"%s\"",
+             this->robot_namespace_.c_str(), this->tf_prefix_.c_str());
+
+  // resolve tf prefix
+  this->frame_name_ = tf::resolve(this->tf_prefix_, this->frame_name_);
+
+  if (this->topic_name_ != "")
+  {
+    ros::AdvertiseOptions ao =
+      ros::AdvertiseOptions::create<sensor_msgs::Range>(
+      this->topic_name_, 1,
+      boost::bind(&GazeboRosSonar::SonarConnect, this),
+      boost::bind(&GazeboRosSonar::SonarDisconnect, this),
+      ros::VoidPtr(), NULL);
+    this->pub_ = this->rosnode_->advertise(ao);
+    this->pub_queue_ = this->pmq.addPub<sensor_msgs::Range>();
+  }
+
+  // Initialize the controller
+
+  // sensor generation off by default
+  this->parent_sonar_sensor_->SetActive(false);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Increment count
+void GazeboRosSonar::SonarConnect()
+{
+  this->sonar_connect_count_++;
+  // this->parent_sonar_sensor_->SetActive(true);
+    if (this->sonar_connect_count_ == 1)
+  this->sonar_sub_ =
+    this->gazebo_node_->Subscribe(this->parent_sonar_sensor_->Topic(),
+                                  &GazeboRosSonar::OnScan, this);
+}
+////////////////////////////////////////////////////////////////////////////////
+// Decrement count
+void GazeboRosSonar::SonarDisconnect()
+{
+  this->sonar_connect_count_--;
+  if (this->sonar_connect_count_ == 0)
+    this->sonar_sub_.reset();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the plugin
+void GazeboRosSonar::OnScan(ConstSonarStampedPtr &_msg)
+{
+  sensor_msgs::Range range_msg_;
+  range_msg_.header.stamp = ros::Time(_msg->time().sec(), _msg->time().nsec());
+  range_msg_.header.frame_id = this->frame_name_;
+
+  range_msg_.radiation_type = sensor_msgs::Range::ULTRASOUND;
+
+  range_msg_.field_of_view = fov_;
+  range_msg_.max_range = this->parent_sonar_sensor_->RangeMax();
+  range_msg_.min_range = this->parent_sonar_sensor_->RangeMin();
+
+  range_msg_.range = _msg->sonar().range();
+  if (range_msg_.range < range_msg_.max_range)
+    range_msg_.range = std::min(range_msg_.range + this->GaussianKernel(0,gaussian_noise_), parent_sonar_sensor_->RangeMax());
+
+  this->pub_queue_->push(range_msg_, this->pub_);
+
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// Utility for adding noise
+double GazeboRosSonar::GaussianKernel(double mu, double sigma)
+{
+  // using Box-Muller transform to generate two independent standard
+  // normally disbributed normal variables see wikipedia
+
+  // normalized uniform random variable
+  double U = static_cast<double>(rand_r(&this->seed)) /
+             static_cast<double>(RAND_MAX);
+
+  // normalized uniform random variable
+  double V = static_cast<double>(rand_r(&this->seed)) /
+             static_cast<double>(RAND_MAX);
+
+  double X = sqrt(-2.0 * ::log(U)) * cos(2.0*M_PI * V);
+  // double Y = sqrt(-2.0 * ::log(U)) * sin(2.0*M_PI * V);
+
+  // there are 2 indep. vars, we'll just use X
+  // scale to our mu and sigma
+  X = sigma * X + mu;
+  return X;
+}
+}

--- a/src/gazebo_plugins/src/SonarPlugin/gazebo_ros_sonar.h
+++ b/src/gazebo_plugins/src/SonarPlugin/gazebo_ros_sonar.h
@@ -1,0 +1,137 @@
+/*
+ * Software License Agreement (Modified BSD License)
+ *
+ *  Copyright (c) 2013, PAL Robotics, S.L.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of PAL Robotics, S.L. nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/** \author Jose Capriles, Moussab Bennehar. */
+
+#ifndef GAZEBO_ROS_RANGE_H
+#define GAZEBO_ROS_RANGE_H
+
+
+#include <string>
+
+#include <boost/bind.hpp>
+#include <boost/thread.hpp>
+
+#include <ros/ros.h>
+#include <ros/advertise_options.h>
+#include <sensor_msgs/Range.h>
+
+#include <sdf/Param.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/TransportTypes.hh>
+#include <gazebo/msgs/MessageTypes.hh>
+#include <gazebo/common/Time.hh>
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/common/Events.hh>
+#include <gazebo/sensors/SensorTypes.hh>
+#include <gazebo/plugins/SonarPlugin.hh> 
+#include <gazebo_plugins/gazebo_ros_utils.h>
+
+#include <gazebo_plugins/PubQueue.h>
+
+namespace gazebo
+{
+
+class GazeboRosSonar : public SonarPlugin
+{
+
+    /// \brief Constructor
+    public: GazeboRosSonar();
+
+    /// \brief Destructor
+    public: ~GazeboRosSonar();
+
+    /// \brief Load the plugin
+    /// \param take in SDF root element
+    public: void Load(sensors::SensorPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Keep track of number of connctions
+    private: int sonar_connect_count_;
+    private: void SonarConnect();
+    private: void SonarDisconnect();
+
+    // Pointer to the model
+    GazeboRosPtr gazebo_ros_;
+    private: std::string world_name_;
+    private: physics::WorldPtr world_;
+    /// \brief The parent sensor
+    private: sensors::SonarSensorPtr parent_sonar_sensor_;
+
+    /// \brief pointer to ros node
+    private: ros::NodeHandle* rosnode_;
+    private: ros::Publisher pub_;
+    private: PubQueue<sensor_msgs::Range>::Ptr pub_queue_;
+
+    /// \brief topic name
+    private: std::string topic_name_;
+
+    /// \brief frame transform name, should match link name
+    private: std::string frame_name_;
+
+    /// \brief tf prefix
+    private: std::string tf_prefix_;
+
+    /// \brief for setting ROS name space
+    private: std::string robot_namespace_;
+
+    /// \brief sensor field of view
+    private: double fov_;
+    /// \brief Gaussian noise
+    private: double gaussian_noise_;
+
+    /// \brief Gaussian noise generator
+    private: double GaussianKernel(double mu, double sigma);
+
+    /// update rate of this sensor
+    private: double update_rate_;
+    private: double update_period_;
+    private: common::Time last_update_time_;
+
+    // deferred load in case ros is blocking
+    private: sdf::ElementPtr sdf;
+    private: void LoadThread();
+    private: boost::thread deferred_load_thread_;
+    private: unsigned int seed;
+
+    private: gazebo::transport::NodePtr gazebo_node_;
+    private: gazebo::transport::SubscriberPtr sonar_sub_;
+    /// \brief Update the controller
+    private: void OnScan(ConstSonarStampedPtr &_msg);
+
+    /// \brief prevents blocking
+    private: PubMultiQueue pmq;
+
+};
+}
+#endif // GAZEBO_ROS_RANGE_H


### PR DESCRIPTION
Hi,

As I’m sure you know, the hector_gazebo_sonar plugin is implemented using Gazebo’s ray sensor, which is essentially a laser scan. As a result, if the sensor’s beam hits the ground, it’s reflected back. I think sensors on the rover models were configured to scan horizontally for that reason, so the beams don’t hit the ground (there is no `vertical` tag in the `scan` configuration). I tried adding a vertical component to the scan myself and the results were sad.

It isn’t ideal to limit the sonar scans to a single horizontal plane, since the real world sensors have much larger fields of view. A block reflects the sonar if it’s held high enough in the claw, and a pile of blocks also reflects the sonar as the rover drives toward them. Neither of those things happen in the simulation.

It turns out that Gazebo actually has a sonar sensor, but until recently no one had written a ROS plugin to use it. However, there’s an open PR ros-simulation/gazebo_ros_pkgs#697 that adds this functionality. Since it’s still open, has been for a few months, and seems to have lost traction in getting merged to the main branch, I suggest pulling the source to be built alongside our other Gazebo plugins.

This pull request brings in the sonar plugin and updates the rover models to use it.
- The `radius` and `fov` are currently set to `0.5`, which represents the sonar cone’s radius at it’s maximum range. 50cm leaves some space between each of the three cones, which I think is reasonable, but hasn’t been measured experimentally. You can set `visualize` to true and regenerate the model files to see the cones in Gazebo client. The field of view could be measured on the physical rover by blocking two of the three sensors with tape and moving an object in front of the sensor at 3m away.
- The `gaussianNoise` is `0.15` which looked good visually, but could also be measured on the physical rover for comparison.

Let me know what you think!
