### PR TITLE
collection_disk/model.sdf: added a final_camera & prelim_camera above home

### DIFF
--- a/simulation/models/collection_disk/model.sdf
+++ b/simulation/models/collection_disk/model.sdf
@@ -17,6 +17,40 @@
 		      </script>
 		    </material>
 		  </visual>
+		  <sensor type="camera" name="prelim_camera">
+				<pose>0 0 13 0.0 1.57079 0.0</pose>
+				<visualize>false</visualize>
+				<update_rate>6.0</update_rate>
+				<camera name="prelim_camera">
+					<image>
+						<width>800</width>
+						<height>800</height>
+						<format>B8G8R8</format>
+					</image>
+				</camera>
+				<plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+					<cameraName>/collection_disk/prelim_camera</cameraName>
+					<imageTopicName>/collection_disk/prelim_camera/image</imageTopicName>
+					<cameraInfoTopicName>/collection_disk/prelim_camera/camera_info</cameraInfoTopicName>
+				</plugin>
+			</sensor>
+			<sensor type="camera" name="final_camera">
+				<pose>0 0 20.1 0.0 1.57079 0.0</pose>
+				<visualize>false</visualize>
+				<update_rate>6.0</update_rate>
+				<camera name="final_camera">
+					<image>
+						<width>1200</width>
+						<height>1200</height>
+						<format>B8G8R8</format>
+					</image>
+				</camera>
+				<plugin name="camera_controller" filename="libgazebo_ros_camera.so">
+					<cameraName>/collection_disk/final_camera</cameraName>
+					<imageTopicName>/collection_disk/final_camera/image</imageTopicName>
+					<cameraInfoTopicName>/collection_disk/final_camera/camera_info</cameraInfoTopicName>
+				</plugin>
+			</sensor>
 		</link>
 		<!-- Score Plugin -->
 		<plugin name="score_sim" filename="libgazebo_plugins_score.so">


### PR DESCRIPTION
This allows you to observe a round without needing to open gazebo by running
`rosrun image_view image_view image:=/collection_disk/final_camera/image`
or
`rosrun image_view image_view image:=/collection_disk/prelim_camera/image`

You could also record the round into a rosbag
`rosbag record -O $bagname --duration $mins\m /collection_disk/prelim_camera/image`
You can then extract the video and save it using this guide.
https://coderwall.com/p/qewf6g/how-to-extract-images-from-a-rosbag-file-and-convert-them-to-video

At Cabrillo I set up a MARV instance and it does all the bag conversions automatically.
https://ternaris.com/marv-robotics/ 

I thought about making the cameras in a launch file but couldn't figure it out.