### PR TITLE
Patch robot localization frames

### DIFF
--- a/launch/swarmie.launch
+++ b/launch/swarmie.launch
@@ -28,6 +28,7 @@
       <param name="imu0" value="/$(arg name)/imu" />
       <param name="two_d_mode" value="true" />
       <param name="world_frame" value="odom" />
+      <param name="base_link_frame_output" value="$(arg name)/base_link" />
       <param name="frequency" value="10" />
 
       <rosparam param="odom0_config">[false, false, false,
@@ -80,6 +81,7 @@
       <param name="imu0" value="/$(arg name)/imu" />
       <param name="two_d_mode" value="true" />
       <param name="world_frame" value="map" />
+      <param name="base_link_frame_output" value="$(arg name)/base_link" />
       <param name="frequency" value="10" />
 
       <rosparam param="odom0_config">[true, true, false,

--- a/misc/rover_onboard_node_launch.sh
+++ b/misc/rover_onboard_node_launch.sh
@@ -115,7 +115,7 @@ rosparam set /$HOSTNAME\_ODOM/odom0 /$HOSTNAME/odom
 rosparam set /$HOSTNAME\_ODOM/imu0 /$HOSTNAME/imu
 rosparam set /$HOSTNAME\_ODOM/odom0_config [false,false,false,false,false,false,true,false,false,false,false,true,false,false,false]
 rosparam set /$HOSTNAME\_ODOM/imu0_config [false,false,false,false,false,true,false,false,false,false,false,true,true,false,false]
-nohup > logs/$HOSTNAME"_odom_EKF_log.txt" rosrun robot_localization ekf_localization_node _two_d_mode:=true _world_frame:=odom _frequency:=10 __name:=$HOSTNAME\_ODOM /odometry/filtered:=/$HOSTNAME/odom/filtered &
+nohup > logs/$HOSTNAME"_odom_EKF_log.txt" rosrun robot_localization ekf_localization_node _two_d_mode:=true _world_frame:=odom _base_link_frame_output:=$HOSTNAME/base_link _frequency:=10 __name:=$HOSTNAME\_ODOM /odometry/filtered:=/$HOSTNAME/odom/filtered &
 
 rosparam set /$HOSTNAME\_MAP/odom0 /$HOSTNAME/odom/navsat
 rosparam set /$HOSTNAME\_MAP/odom1 /$HOSTNAME/odom/filtered
@@ -157,7 +157,7 @@ rosparam set $HOSTNAME\_MAP/process_noise_covariance "[0.005, 0, 0, 0, 0, 0, 0, 
                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1, 0,  /
                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0.1]"
 
-nohup > logs/$HOSTNAME"_map_EKF_log.txt" rosrun robot_localization ekf_localization_node _two_d_mode:=true _world_frame:=map _frequency:=10 __name:=$HOSTNAME\_MAP /odometry/filtered:=/$HOSTNAME/odom/ekf &
+nohup > logs/$HOSTNAME"_map_EKF_log.txt" rosrun robot_localization ekf_localization_node _two_d_mode:=true _world_frame:=map _base_link_frame_output:=$HOSTNAME/base_link _frequency:=10 __name:=$HOSTNAME\_MAP /odometry/filtered:=/$HOSTNAME/odom/ekf &
 
 throttle()
 {


### PR DESCRIPTION
Hi guys,

A recent update to `robot_localization` added a new parameter, `base_link_frame_output`, which is used as the `child_frame_id` in published `Odometry` messages and the `odom->base_link` transform.

The new parameter defaults to the `base_link` parameter's value, before prepending the `tf_prefix`. However, the `base_link_frame_output` parameter doesn't currently get the `tf_prefix` prepended to its value. As a result, the `/<rovername>_ODOM` node generates a `<rovername>/odom -> base_link` transform and publishes messages to `/<rovername>/odom/filtered` with `frame_id=<rovername>/odom` and `child_frame_id=base_link`, causing the `/<rovername>_MAP` node to fail while looking up a required transform.

The disconnected and invalid tf tree looks like this:

![brokenframes](https://user-images.githubusercontent.com/32401097/54080804-28a22080-42ad-11e9-91b3-6ea2b9bbd315.png)

And the warning message logged by `/<rovername>_MAP` looks like this:

`[ WARN] [1552193204.070637937, 662.963000000]: Could not obtain transform from base_link to achilles/base_link. Error was Could not find a connection between 'achilles/base_link' and 'base_link' because they are not part of the same tree.Tf has two or more unconnected trees.`

There are a couple of ways to fix this issue. One is here in this PR, which is to simply set the `base_link_frame_output` parameter explicitly, prefixed with the rover name. However, if the `robot_localization` package begins using the `tf_prefix` for this parameter, it will break this, and you'll have to pull these lines out again.

Another option is to remove the `tf_prefix` parameter altogether, and set any `robot_localization` parameters with explicit prefixes for the rover name. I'll put that fix up on a different PR.

It's important to patch this so you can hopefully provide an image with a much later freeze date than Jan 7th. I'm sure many developers are updating packages on their workstations, and I've encountered binary incompatibilities between released versions of at least one package on the Preinstalled Packages list, causing seg faults while running code built on a up-to-date laptop and deployed to a rover with older packages installed.